### PR TITLE
Add CSV download and iframe embed buttons to faillissementen analysis

### DIFF
--- a/embuild-analyses/src/components/analyses/faillissementen/FaillissementenDashboard.tsx
+++ b/embuild-analyses/src/components/analyses/faillissementen/FaillissementenDashboard.tsx
@@ -719,10 +719,31 @@ function DurationSection({
 
   const totalBankruptcies = data.reduce((sum, r) => sum + r.n, 0)
 
+  const exportData = React.useMemo(
+    () =>
+      data.map((d) => ({
+        label: d.ds,
+        value: d.n,
+        periodCells: [String(selectedYear), d.ds],
+      })),
+    [data, selectedYear]
+  )
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold">Leeftijd gefailleerde bedrijven</h2>
+        <ExportButtons
+          data={exportData}
+          title="Bedrijfsleeftijd faillissementen bouwsector"
+          slug="faillissementen"
+          sectionId="leeftijd"
+          viewType="table"
+          periodHeaders={["Jaar", "Bedrijfsleeftijd"]}
+          valueLabel="Faillissementen"
+          dataSource="Statbel - Faillissementen"
+          dataSourceUrl="https://statbel.fgov.be/nl/themas/ondernemingen/faillissementen"
+        />
       </div>
 
       <div className="flex flex-wrap items-center justify-end gap-2 mb-4">
@@ -833,10 +854,31 @@ function WorkersSection({
   const smallCompanies = data.filter(r => r.c === "0 - 4 werknemers")
   const smallCompanyCount = smallCompanies.reduce((sum, r) => sum + r.n, 0)
 
+  const exportData = React.useMemo(
+    () =>
+      data.map((d) => ({
+        label: d.c,
+        value: d.n,
+        periodCells: [String(selectedYear), d.c],
+      })),
+    [data, selectedYear]
+  )
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold">Bedrijfsgrootte</h2>
+        <ExportButtons
+          data={exportData}
+          title="Bedrijfsgrootte faillissementen bouwsector"
+          slug="faillissementen"
+          sectionId="bedrijfsgrootte"
+          viewType="table"
+          periodHeaders={["Jaar", "Bedrijfsgrootte"]}
+          valueLabel="Faillissementen"
+          dataSource="Statbel - Faillissementen"
+          dataSourceUrl="https://statbel.fgov.be/nl/themas/ondernemingen/faillissementen"
+        />
       </div>
 
       <div className="flex flex-wrap items-center justify-end gap-2 mb-4">
@@ -935,10 +977,31 @@ function SectorComparisonSection({
   const constructionData = data.find((d) => d.sector === "F")
   const constructionRank = data.findIndex((d) => d.sector === "F") + 1
 
+  const exportData = React.useMemo(
+    () =>
+      data.map((d) => ({
+        label: d.name,
+        value: d.n,
+        periodCells: [String(selectedYear), d.name],
+      })),
+    [data, selectedYear]
+  )
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold">Sectorvergelijking</h2>
+        <ExportButtons
+          data={exportData}
+          title="Sectorvergelijking faillissementen"
+          slug="faillissementen"
+          sectionId="sectoren"
+          viewType="table"
+          periodHeaders={["Jaar", "Sector"]}
+          valueLabel="Faillissementen"
+          dataSource="Statbel - Faillissementen"
+          dataSourceUrl="https://statbel.fgov.be/nl/themas/ondernemingen/faillissementen"
+        />
       </div>
 
       {constructionData && (


### PR DESCRIPTION
Added ExportButtons component to three sections that were missing them:
- SectorComparisonSection (sectoren)
- DurationSection (leeftijd)
- WorkersSection (bedrijfsgrootte)

Each section now provides CSV export and iframe embed functionality for better data sharing and integration.

Fixes #3

Generated with [Claude Code](https://claude.ai/code)