### PR TITLE
fix: Extract Belgian province codes to shared JSON and add documentation

### DIFF
--- a/embuild-analyses/analyses/faillissementen/src/process_faillissementen.py
+++ b/embuild-analyses/analyses/faillissementen/src/process_faillissementen.py
@@ -52,23 +52,13 @@ SECTOR_NAMES = {
     "?": "Onbekend",
 }
 
-# Belgian province codes (all provinces including Flanders, Wallonia, and Brussels)
-BELGIAN_PROVINCES = {
-    # Flemish provinces
-    10000: "Antwerpen",
-    20001: "Vlaams-Brabant",
-    30000: "West-Vlaanderen",
-    40000: "Oost-Vlaanderen",
-    70000: "Limburg",
-    # Walloon provinces
-    20002: "Waals-Brabant",
-    50000: "Henegouwen",
-    60000: "Luik",
-    80000: "Luxemburg",
-    90000: "Namen",
-    # Brussels
-    21000: "Brussel",
-}
+# Load Belgian province codes from shared JSON file
+# Note: Brussels (21000) is technically an arrondissement, not a province, but is treated
+# as a province-equivalent for visualization purposes since Brussels Capital Region has no
+# province-level administrative division in the NIS hierarchy.
+SHARED_DATA_DIR = SCRIPT_DIR.parent.parent.parent / "shared-data"
+with open(SHARED_DATA_DIR / "belgian-provinces.json", "r") as f:
+    BELGIAN_PROVINCES = {int(k): v for k, v in json.load(f).items()}
 
 
 def download_data() -> pd.DataFrame:

--- a/embuild-analyses/scripts/check-faillissementen-geo-join.js
+++ b/embuild-analyses/scripts/check-faillissementen-geo-join.js
@@ -13,27 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 
-// Paths
-const ANALYSIS_DIR = path.join(__dirname, '../analyses/faillissementen');
-const RESULTS_DIR = path.join(ANALYSIS_DIR, 'results');
-const SHARED_DATA_DIR = path.join(__dirname, '../shared-data');
-const ALLOWLIST_PATH = path.join(__dirname, 'faillissementen-geo-join-allowlist.json');
-
-// Belgian province codes (matching the Python script)
-const BELGIAN_PROVINCES = {
-  '10000': 'Antwerpen',
-  '20001': 'Vlaams-Brabant',
-  '30000': 'West-Vlaanderen',
-  '40000': 'Oost-Vlaanderen',
-  '70000': 'Limburg',
-  '20002': 'Waals-Brabant',
-  '50000': 'Henegouwen',
-  '60000': 'Luik',
-  '80000': 'Luxemburg',
-  '90000': 'Namen',
-  '21000': 'Brussel',
-};
-
+// Helper function to load JSON files
 function loadJSON(filepath) {
   try {
     const content = fs.readFileSync(filepath, 'utf8');
@@ -43,6 +23,16 @@ function loadJSON(filepath) {
     process.exit(1);
   }
 }
+
+// Paths
+const ANALYSIS_DIR = path.join(__dirname, '../analyses/faillissementen');
+const RESULTS_DIR = path.join(ANALYSIS_DIR, 'results');
+const SHARED_DATA_DIR = path.join(__dirname, '../shared-data');
+const ALLOWLIST_PATH = path.join(__dirname, 'faillissementen-geo-join-allowlist.json');
+
+// Load Belgian province codes from shared JSON file
+// Note: Brussels (21000) is an arrondissement treated as province-equivalent for visualization
+const BELGIAN_PROVINCES = loadJSON(path.join(SHARED_DATA_DIR, 'belgian-provinces.json'));
 
 function loadAllowlist() {
   if (fs.existsSync(ALLOWLIST_PATH)) {

--- a/embuild-analyses/shared-data/belgian-provinces.json
+++ b/embuild-analyses/shared-data/belgian-provinces.json
@@ -1,0 +1,13 @@
+{
+  "10000": "Antwerpen",
+  "20001": "Vlaams-Brabant",
+  "30000": "West-Vlaanderen",
+  "40000": "Oost-Vlaanderen",
+  "70000": "Limburg",
+  "20002": "Waals-Brabant",
+  "50000": "Henegouwen",
+  "60000": "Luik",
+  "80000": "Luxemburg",
+  "90000": "Namen",
+  "21000": "Brussel"
+}


### PR DESCRIPTION
## Summary

Addresses medium priority items from issue #9:
- Documents Brussels special case (21000 arrondissement treated as province-equivalent)
- Extracts province codes to shared JSON file to avoid Python/JS duplication

## Changes
- Created `embuild-analyses/shared-data/belgian-provinces.json` as single source of truth
- Updated Python script to load province codes from shared JSON
- Updated validation script to load province codes from shared JSON
- Added explanatory comments about Brussels in both files

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)