### PR TITLE
fix: correct return type in faillissementen dashboard

### DIFF
--- a/embuild-analyses/src/components/analyses/faillissementen/FaillissementenDashboard.tsx
+++ b/embuild-analyses/src/components/analyses/faillissementen/FaillissementenDashboard.tsx
@@ -276,20 +276,22 @@ function useSectorOptions(): { sectors: Sector[]; error: string | null } {
   if (isValidLookups(lookups)) {
     return { sectors: lookups.sectors, error: null }
   }
-  return safeArrayAccess<Sector>(
+  const { data, error } = safeArrayAccess<Sector>(
     (lookups as Record<string, unknown>).sectors,
     'sectorgegevens'
   )
+  return { sectors: data, error }
 }
 
 function useProvinceOptions(): { provinces: Province[]; error: string | null } {
   if (isValidLookups(lookups)) {
     return { provinces: lookups.provinces, error: null }
   }
-  return safeArrayAccess<Province>(
+  const { data, error } = safeArrayAccess<Province>(
     (lookups as Record<string, unknown>).provinces,
     'provinciegegevens'
   )
+  return { provinces: data, error }
 }
 
 // Sector filter dropdown


### PR DESCRIPTION
Fixes TypeScript compilation error in FaillissementenDashboard.tsx.

The `safeArrayAccess` function returns `{ data, error }`, but `useSectorOptions` and `useProvinceOptions` need to return objects with specific property names (`sectors` and `provinces`). Fixed by destructuring and renaming.

Fixes #20

Generated with [Claude Code](https://claude.ai/code)