### PR TITLE
fix: remove non-existent building type from housing permit filter

### DIFF
--- a/embuild-analyses/analyses/vergunningen-aanvragen/src/process_vergunningen.py
+++ b/embuild-analyses/analyses/vergunningen-aanvragen/src/process_vergunningen.py
@@ -75,8 +75,7 @@ woningen_functies = [
     "meergezinswoning",
     "kamerwoning",
     "eengezins- en kamerwoning",
-    "meergezins- en kamerwoning",
-    "eengezins- en meergezinswoning"
+    "meergezins- en kamerwoning"
 ]
 
 # ============================================================================


### PR DESCRIPTION
Fixes #22

Removed 'eengezins- en meergezinswoning' from the woningen_functies filter in the housing permit processing script, as this category does not exist in the actual data from Omgevingsloket.

All actual housing types in the data remain correctly included.

Generated with [Claude Code](https://claude.ai/code)