### PR TITLE
fix: read correct Excel sheet in prijsherziening data processor

### DIFF
--- a/embuild-analyses/analyses/prijsherziening-index-i-2021/src/process_prijsherziening.py
+++ b/embuild-analyses/analyses/prijsherziening-index-i-2021/src/process_prijsherziening.py
@@ -80,8 +80,8 @@ def process_data(excel_path: str) -> None:
     xl_file = pd.ExcelFile(excel_path)
     print(f"Excel sheets: {xl_file.sheet_names}")
 
-    # Read the first sheet (assuming it contains the data)
-    df = pd.read_excel(excel_path, sheet_name=0)
+    # Read the Dutch data sheet (I_2021 (Nl))
+    df = pd.read_excel(excel_path, sheet_name='I_2021 (Nl)')
     print(f"Loaded {len(df)} rows, {len(df.columns)} columns")
     print(f"Columns: {df.columns.tolist()}")
 


### PR DESCRIPTION
Fixes #41

The script was reading sheet 0 (language choice) instead of the actual data sheet 'I_2021 (Nl)'. This caused a KeyError when trying to pivot the data because no 'value' column existed in the language selection sheet.

### Changes
- Updated line 84 to read the Dutch data sheet instead of sheet 0

Generated with [Claude Code](https://claude.ai/code)