### PR TITLE
fix: correct YAML frontmatter in prijsherziening content

### DIFF
--- a/embuild-analyses/analyses/prijsherziening-index-i-2021/content.mdx
+++ b/embuild-analyses/analyses/prijsherziening-index-i-2021/content.mdx
@@ -7,7 +7,8 @@ slug: prijsherziening-index-i-2021
 sourceProvider: FOD Economie
 sourceTitle: Prijsherzieningsindexen - Mercuriale Index I 2021
 sourceUrl: https://economie.fgov.be/nl/themas/ondernemingen/specifieke-sectoren/bouw/prijsherzieningsindexen/mercuriale-index-i-2021
-sourcePublicationDate: 2026-01-30---
+sourcePublicationDate: 2026-01-30
+---
 
 import { PrijsherzieningDashboard } from "@/components/analyses/prijsherziening/PrijsherzieningDashboard"
 


### PR DESCRIPTION
Fixed YAML parsing error in the prijsherziening blog post where the closing `---` marker was on the same line as the `sourcePublicationDate` value.

The frontmatter closing marker must be on its own line according to YAML syntax.

Fixes #44

---
Generated with [Claude Code](https://claude.ai/code)