### PR TITLE
fix: add missing content.mdx for energiekaart-premies

### DIFF
--- a/embuild-analyses/analyses/energiekaart-premies/content.mdx
+++ b/embuild-analyses/analyses/energiekaart-premies/content.mdx
@@ -1,0 +1,34 @@
+---
+title: Energiepremies Vlaanderen
+date: 2025-12-27
+summary: Analyse van energiepremies voor residentiële gebouwen in Vlaanderen op basis van de Energiekaart PowerBI dashboard.
+tags: [energie, premies, renovatie, vlaanderen]
+slug: energiekaart-premies
+sourceProvider: Vlaams Energieagentschap
+sourceTitle: Energiekaart - Premies Tijdreeks
+sourceUrl: https://apps.energiesparen.be/energiekaart/vlaanderen/premies-res-tijdreeks-algemeen
+---
+
+# Energiepremies Vlaanderen
+
+Deze analyse toont de evolutie van energiepremies voor residentiële gebouwen in Vlaanderen. De data wordt geëxtraheerd uit het officiële Energiekaart PowerBI dashboard van het Vlaams Energieagentschap.
+
+## Over de data
+
+De energiepremies ondersteunen Vlaamse gezinnen bij energiebesparende renovaties en investeringen in hernieuwbare energie. Het dashboard toont tijdreeksen van:
+
+- Aantal toegekende premies
+- Totaal bedrag aan uitbetaalde premies
+- Verdeling per type premie en gemeente
+
+## Analyse
+
+_De visualisaties en interactieve componenten worden binnenkort toegevoegd._
+
+---
+
+### Bron
+
+De data voor deze analyse komt van het [Energiekaart Dashboard - Premies Tijdreeks](https://apps.energiesparen.be/energiekaart/vlaanderen/premies-res-tijdreeks-algemeen) van het Vlaams Energieagentschap.
+
+De data wordt automatisch geëxtraheerd via een geautomatiseerd script dat het PowerBI dashboard analyseert en de onderliggende data exporteert.


### PR DESCRIPTION
Fixes #50

Adds the missing `content.mdx` file for the energiekaart-premies analysis, which will make it appear on the main blog page.

The energiekaart-premies directory existed with data extraction scripts but was missing the required content file that Contentlayer needs to generate the blog card.

## Changes
- Created `analyses/energiekaart-premies/content.mdx` with proper frontmatter
- Added title, summary, tags, and source information
- Added placeholder content explaining the analysis

----

Generated with [Claude Code](https://claude.ai/code)