### PR TITLE
feat: add embed support for remaining analyses

### DIFF
--- a/embuild-analyses/src/app/embed/[slug]/[section]/EmbedClient.tsx
+++ b/embuild-analyses/src/app/embed/[slug]/[section]/EmbedClient.tsx
@@ -3,6 +3,9 @@
 import React, { useEffect, useState } from "react"
 import { EmbeddableSection } from "@/components/analyses/shared/EmbeddableSection"
 import { StartersStoppersEmbed } from "@/components/analyses/starters-stoppers/StartersStoppersEmbed"
+import { VastgoedVerkopenEmbed } from "@/components/analyses/vastgoed-verkopen/VastgoedVerkopenEmbed"
+import { FaillissementenEmbed } from "@/components/analyses/faillissementen/FaillissementenEmbed"
+import { HuishoudensgroeiEmbed } from "@/components/analyses/huishoudensgroei/HuishoudensgroeiEmbed"
 import { ProvinceCode, RegionCode } from "@/lib/geo-utils"
 import { getEmbedConfig } from "@/lib/embed-config"
 import { EmbedDataRow, MunicipalityData } from "@/lib/embed-types"
@@ -194,6 +197,77 @@ export function EmbedClient({ slug, section }: EmbedClientProps) {
           region={urlParams.region}
           province={urlParams.province}
           sector={urlParams.sector}
+        />
+      )
+    }
+
+    // Handle VastgoedVerkopenEmbed
+    if (config.component === "VastgoedVerkopenEmbed") {
+      const validSections = ["transacties", "prijzen", "transacties-kwartaal", "prijzen-kwartaal"]
+      if (!validSections.includes(section)) {
+        return (
+          <div className="p-8 text-center">
+            <p className="text-muted-foreground">
+              Ongeldige sectie: {section}
+            </p>
+          </div>
+        )
+      }
+
+      return (
+        <VastgoedVerkopenEmbed
+          section={section as "transacties" | "prijzen" | "transacties-kwartaal" | "prijzen-kwartaal"}
+          viewType={urlParams.view}
+          geo={urlParams.region}
+          type={urlParams.sector}
+        />
+      )
+    }
+
+    // Handle FaillissementenEmbed
+    if (config.component === "FaillissementenEmbed") {
+      const validSections = ["evolutie", "leeftijd", "bedrijfsgrootte", "sectoren"]
+      if (!validSections.includes(section)) {
+        return (
+          <div className="p-8 text-center">
+            <p className="text-muted-foreground">
+              Ongeldige sectie: {section}
+            </p>
+          </div>
+        )
+      }
+
+      return (
+        <FaillissementenEmbed
+          section={section as "evolutie" | "leeftijd" | "bedrijfsgrootte" | "sectoren"}
+          viewType={urlParams.view}
+          sector={urlParams.sector ?? "F"}
+          year={urlParams.horizon}
+          timeRange={(urlParams.view === "table" || urlParams.view === "map") ? "yearly" : "monthly"}
+        />
+      )
+    }
+
+    // Handle HuishoudensgroeiEmbed
+    if (config.component === "HuishoudensgroeiEmbed") {
+      const validSections = ["evolutie", "ranking", "size-breakdown"]
+      if (!validSections.includes(section)) {
+        return (
+          <div className="p-8 text-center">
+            <p className="text-muted-foreground">
+              Ongeldige sectie: {section}
+            </p>
+          </div>
+        )
+      }
+
+      return (
+        <HuishoudensgroeiEmbed
+          section={section as "evolutie" | "ranking" | "size-breakdown"}
+          viewType={urlParams.view}
+          geo={urlParams.region}
+          horizonYear={urlParams.horizon ?? 2033}
+          showDecline={urlParams.sector === "decline"}
         />
       )
     }

--- a/embuild-analyses/src/components/analyses/faillissementen/FaillissementenEmbed.tsx
+++ b/embuild-analyses/src/components/analyses/faillissementen/FaillissementenEmbed.tsx
@@ -1,0 +1,256 @@
+"use client"
+
+import { useMemo } from "react"
+import { FilterableChart } from "../shared/FilterableChart"
+import { FilterableTable } from "../shared/FilterableTable"
+
+import monthlyConstruction from "../../../../analyses/faillissementen/results/monthly_construction.json"
+import monthlyTotals from "../../../../analyses/faillissementen/results/monthly_totals.json"
+import yearlyConstruction from "../../../../analyses/faillissementen/results/yearly_construction.json"
+import yearlyTotals from "../../../../analyses/faillissementen/results/yearly_totals.json"
+import yearlyByDuration from "../../../../analyses/faillissementen/results/yearly_by_duration.json"
+import yearlyByDurationConstruction from "../../../../analyses/faillissementen/results/yearly_by_duration_construction.json"
+import yearlyByWorkers from "../../../../analyses/faillissementen/results/yearly_by_workers.json"
+import yearlyByWorkersConstruction from "../../../../analyses/faillissementen/results/yearly_by_workers_construction.json"
+import yearlyBySector from "../../../../analyses/faillissementen/results/yearly_by_sector.json"
+import lookups from "../../../../analyses/faillissementen/results/lookups.json"
+import metadata from "../../../../analyses/faillissementen/results/metadata.json"
+
+type MonthlyRow = {
+  y: number
+  m: number
+  n: number
+  w: number
+}
+
+type YearlyRow = {
+  y: number
+  n: number
+  w: number
+}
+
+type DurationRow = {
+  y: number
+  d: string
+  ds: string
+  do: number
+  n: number
+  w: number
+}
+
+type WorkersRow = {
+  y: number
+  c: string
+  n: number
+  w: number
+}
+
+type YearlySectorRow = {
+  y: number
+  s: string
+  n: number
+  w: number
+}
+
+type Sector = {
+  code: string
+  nl: string
+}
+
+type ChartPoint = {
+  sortValue: number
+  periodCells: Array<string | number>
+  value: number
+}
+
+type SectionType = "evolutie" | "leeftijd" | "bedrijfsgrootte" | "sectoren"
+type ViewType = "chart" | "table"
+
+const MONTH_NAMES = [
+  "Jan", "Feb", "Mrt", "Apr", "Mei", "Jun",
+  "Jul", "Aug", "Sep", "Okt", "Nov", "Dec"
+]
+
+const WORKER_CLASS_ORDER = [
+  "0 - 4 werknemers",
+  "5 - 9 werknemers",
+  "10 - 19 werknemers",
+  "20 - 49 werknemers",
+  "50 - 99 werknemers",
+  "100 - 199 werknemers",
+  "200 - 249 werknemers",
+  "250 - 499 werknemers",
+  "500 - 999 werknemers",
+  "1000 werknemers en meer",
+  "1000 en meer werknemers",
+]
+
+function formatInt(n: number) {
+  return new Intl.NumberFormat("nl-BE", { maximumFractionDigits: 0 }).format(n)
+}
+
+function getMonthlyData(sector: string, months: number = 24): ChartPoint[] {
+  const data = sector === "ALL"
+    ? (monthlyTotals as MonthlyRow[])
+    : (monthlyConstruction as MonthlyRow[])
+
+  return data
+    .map((r) => ({
+      sortValue: r.y * 100 + r.m,
+      periodCells: [`${MONTH_NAMES[r.m - 1]} ${r.y}`],
+      value: r.n,
+    }))
+    .sort((a, b) => a.sortValue - b.sortValue)
+    .slice(-months)
+}
+
+function getYearlyData(sector: string): ChartPoint[] {
+  const data = sector === "ALL"
+    ? (yearlyTotals as YearlyRow[])
+    : (yearlyConstruction as YearlyRow[])
+
+  return data
+    .map((r) => ({
+      sortValue: r.y,
+      periodCells: [r.y],
+      value: r.n,
+    }))
+    .sort((a, b) => a.sortValue - b.sortValue)
+}
+
+function getDurationData(sector: string, year: number): Array<{ label: string; value: number; sortValue: number }> {
+  const data = (sector === "F"
+    ? (yearlyByDurationConstruction as DurationRow[])
+    : (yearlyByDuration as DurationRow[])
+  ).filter((r) => r.y === year)
+
+  return data
+    .map((r) => ({
+      label: r.ds,
+      value: r.n,
+      sortValue: r.do,
+    }))
+    .sort((a, b) => a.sortValue - b.sortValue)
+}
+
+function getWorkersData(sector: string, year: number): Array<{ label: string; value: number; sortValue: number }> {
+  const data = (sector === "F"
+    ? (yearlyByWorkersConstruction as WorkersRow[])
+    : (yearlyByWorkers as WorkersRow[])
+  ).filter((r) => r.y === year)
+
+  return data
+    .map((r) => {
+      const idx = WORKER_CLASS_ORDER.indexOf(r.c)
+      return {
+        label: r.c,
+        value: r.n,
+        sortValue: idx === -1 ? 999 : idx,
+      }
+    })
+    .sort((a, b) => a.sortValue - b.sortValue)
+}
+
+function getSectorData(year: number): Array<{ label: string; value: number; sector: string }> {
+  const sectors = (lookups as { sectors: Sector[] }).sectors ?? []
+  const data = (yearlyBySector as YearlySectorRow[]).filter((r) => r.y === year)
+
+  return data
+    .map((r) => ({
+      sector: r.s,
+      label: sectors.find((s) => s.code === r.s)?.nl ?? r.s,
+      value: r.n,
+    }))
+    .sort((a, b) => b.value - a.value)
+    .slice(0, 10)
+}
+
+interface FaillissementenEmbedProps {
+  section: SectionType
+  viewType: ViewType
+  sector?: string
+  year?: number
+  timeRange?: "monthly" | "yearly"
+}
+
+export function FaillissementenEmbed({
+  section,
+  viewType,
+  sector = "F",
+  year = metadata.max_year,
+  timeRange = "monthly",
+}: FaillissementenEmbedProps) {
+  const data = useMemo(() => {
+    switch (section) {
+      case "evolutie":
+        return timeRange === "monthly" ? getMonthlyData(sector, 36) : getYearlyData(sector)
+      case "leeftijd":
+        return getDurationData(sector, year).map((d) => ({
+          sortValue: d.sortValue,
+          periodCells: [d.label],
+          value: d.value,
+        }))
+      case "bedrijfsgrootte":
+        return getWorkersData(sector, year).map((d) => ({
+          sortValue: d.sortValue,
+          periodCells: [d.label],
+          value: d.value,
+        }))
+      case "sectoren":
+        return getSectorData(year).map((d, i) => ({
+          sortValue: i,
+          periodCells: [d.label],
+          value: d.value,
+        }))
+    }
+  }, [section, sector, year, timeRange])
+
+  const title = useMemo(() => {
+    switch (section) {
+      case "evolutie":
+        return sector === "ALL"
+          ? `Evolutie faillissementen - ${timeRange === "monthly" ? "maandelijks" : "jaarlijks"}`
+          : `Evolutie bouwsector - ${timeRange === "monthly" ? "maandelijks" : "jaarlijks"}`
+      case "leeftijd":
+        return "Bedrijfsleeftijd gefailleerde bedrijven"
+      case "bedrijfsgrootte":
+        return "Bedrijfsgrootte gefailleerde bedrijven"
+      case "sectoren":
+        return "Top 10 sectoren met meeste faillissementen"
+    }
+  }, [section, sector, timeRange])
+
+  const periodHeaders = section === "evolutie" && timeRange === "monthly" ? ["Maand"] : ["Categorie"]
+
+  return (
+    <div className="p-4">
+      <h2 className="text-lg font-semibold mb-4">{title}</h2>
+
+      {viewType === "chart" && section === "evolutie" && (
+        <FilterableChart
+          data={data}
+          getLabel={(d) => String((d as ChartPoint).periodCells[0])}
+          getValue={(d) => (d as ChartPoint).value}
+          getSortValue={(d) => (d as ChartPoint).sortValue}
+        />
+      )}
+
+      {viewType === "table" && (
+        <FilterableTable data={data} label="Faillissementen" periodHeaders={periodHeaders} />
+      )}
+
+      <div className="mt-4 text-xs text-muted-foreground text-center">
+        <a
+          href={typeof window !== "undefined" ? window.location.origin + (process.env.NODE_ENV === "production" ? "/data-blog" : "") : ""}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline"
+        >
+          Data Blog
+        </a>
+        {" · "}
+        <span>Bron: Statbel</span>
+      </div>
+    </div>
+  )
+}

--- a/embuild-analyses/src/components/analyses/huishoudensgroei/HuishoudensgroeiEmbed.tsx
+++ b/embuild-analyses/src/components/analyses/huishoudensgroei/HuishoudensgroeiEmbed.tsx
@@ -1,0 +1,223 @@
+"use client"
+
+import { useMemo } from "react"
+import { FilterableChart } from "../shared/FilterableChart"
+import { FilterableTable } from "../shared/FilterableTable"
+
+import municipalitiesRaw from "../../../../analyses/huishoudensgroei/results/municipalities.json"
+import provincesRaw from "../../../../analyses/huishoudensgroei/results/provinces.json"
+import regionRaw from "../../../../analyses/huishoudensgroei/results/region.json"
+import regionBySizeRaw from "../../../../analyses/huishoudensgroei/results/region_by_size.json"
+import provincesBySizeRaw from "../../../../analyses/huishoudensgroei/results/provinces_by_size.json"
+import lookups from "../../../../analyses/huishoudensgroei/results/lookups.json"
+
+type MunicipalityRow = {
+  y: number
+  nis: string
+  n: number
+  name: string | null
+  p: string | null
+  gr: number | null
+}
+
+type ProvinceRow = {
+  y: number
+  p: string
+  n: number
+  gr: number | null
+}
+
+type RegionRow = {
+  y: number
+  r: string
+  n: number
+  gr: number | null
+}
+
+type SizeRow = {
+  y: number
+  hh: string
+  n: number
+  r?: string
+  p?: string
+}
+
+type HouseholdSize = {
+  code: string
+  nl: string
+}
+
+type YearPoint = {
+  sortValue: number
+  periodCells: Array<string | number>
+  value: number
+}
+
+type SectionType = "evolutie" | "ranking" | "size-breakdown"
+type ViewType = "chart" | "table"
+
+const BASE_YEAR = 2023
+
+function formatInt(n: number) {
+  return new Intl.NumberFormat("nl-BE", { maximumFractionDigits: 0 }).format(n)
+}
+
+function formatPct(n: number) {
+  const sign = n >= 0 ? "+" : ""
+  return `${sign}${n.toFixed(1)}%`
+}
+
+function getYearSeries(
+  level: "vlaanderen" | "province" | "municipality",
+  code: string | null,
+  maxYear: number
+): YearPoint[] {
+  let data: Array<{ y: number; n: number }>
+
+  if (level === "municipality" && code) {
+    data = (municipalitiesRaw as MunicipalityRow[]).filter((r) => r.nis === code && r.y <= maxYear)
+  } else if (level === "province" && code) {
+    data = (provincesRaw as ProvinceRow[]).filter((r) => r.p === code && r.y <= maxYear)
+  } else {
+    data = (regionRaw as RegionRow[]).filter((r) => r.y <= maxYear)
+  }
+
+  return data
+    .map((r) => ({
+      sortValue: r.y,
+      periodCells: [r.y],
+      value: r.n,
+    }))
+    .sort((a, b) => a.sortValue - b.sortValue)
+}
+
+function getMunicipalityRanking(
+  year: number,
+  limit: number = 10,
+  ascending: boolean = false
+): Array<{ name: string; gr: number; n: number }> {
+  const data = (municipalitiesRaw as MunicipalityRow[]).filter(
+    (r) => r.y === year && r.gr !== null && r.name !== null
+  )
+
+  return data
+    .map((r) => ({
+      name: r.name!,
+      gr: r.gr!,
+      n: r.n,
+    }))
+    .sort((a, b) => (ascending ? a.gr - b.gr : b.gr - a.gr))
+    .slice(0, limit)
+}
+
+function getSizeBreakdown(
+  level: "vlaanderen" | "province",
+  code: string | null,
+  year: number
+): Array<{ label: string; value: number }> {
+  const householdSizes = (lookups as { household_sizes: HouseholdSize[] }).household_sizes ?? []
+
+  let data: SizeRow[]
+  if (level === "province" && code) {
+    data = (provincesBySizeRaw as SizeRow[]).filter((r) => r.p === code && r.y === year)
+  } else {
+    data = (regionBySizeRaw as SizeRow[]).filter((r) => r.y === year)
+  }
+
+  return data.map((r) => ({
+    label: householdSizes.find((h) => h.code === r.hh)?.nl ?? r.hh,
+    value: r.n,
+  }))
+}
+
+interface HuishoudensgroeiEmbedProps {
+  section: SectionType
+  viewType: ViewType
+  geo?: string | null
+  horizonYear?: number
+  showDecline?: boolean
+}
+
+export function HuishoudensgroeiEmbed({
+  section,
+  viewType,
+  geo = null,
+  horizonYear = 2033,
+  showDecline = false,
+}: HuishoudensgroeiEmbedProps) {
+  const data = useMemo(() => {
+    switch (section) {
+      case "evolutie":
+        return getYearSeries("vlaanderen", null, horizonYear)
+      case "ranking": {
+        const ranking = getMunicipalityRanking(horizonYear, 10, showDecline)
+        return ranking.map((r, i) => ({
+          sortValue: i,
+          periodCells: [r.name],
+          value: r.gr,
+        }))
+      }
+      case "size-breakdown": {
+        const breakdown = getSizeBreakdown("vlaanderen", null, horizonYear)
+        return breakdown.map((item, i) => ({
+          sortValue: i,
+          periodCells: [item.label],
+          value: item.value,
+        }))
+      }
+    }
+  }, [section, horizonYear, showDecline])
+
+  const title = useMemo(() => {
+    switch (section) {
+      case "evolutie":
+        return `Evolutie aantal huishoudens (tot ${horizonYear})`
+      case "ranking":
+        return showDecline
+          ? "Gemeenten met sterkste afname"
+          : "Snelst groeiende gemeenten"
+      case "size-breakdown":
+        return "Samenstelling huishoudens"
+    }
+  }, [section, horizonYear, showDecline])
+
+  const label = section === "evolutie"
+    ? "Huishoudens"
+    : section === "ranking"
+      ? "Groei (%)"
+      : "Aantal"
+
+  const periodHeaders = section === "evolutie" ? ["Jaar"] : ["Categorie"]
+
+  return (
+    <div className="p-4">
+      <h2 className="text-lg font-semibold mb-4">{title}</h2>
+
+      {viewType === "chart" && section === "evolutie" && (
+        <FilterableChart
+          data={data}
+          getLabel={(d) => String((d as YearPoint).periodCells[0])}
+          getValue={(d) => (d as YearPoint).value}
+          getSortValue={(d) => (d as YearPoint).sortValue}
+        />
+      )}
+
+      {viewType === "table" && (
+        <FilterableTable data={data} label={label} periodHeaders={periodHeaders} />
+      )}
+
+      <div className="mt-4 text-xs text-muted-foreground text-center">
+        <a
+          href={typeof window !== "undefined" ? window.location.origin + (process.env.NODE_ENV === "production" ? "/data-blog" : "") : ""}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline"
+        >
+          Data Blog
+        </a>
+        {" · "}
+        <span>Bron: Statistiek Vlaanderen</span>
+      </div>
+    </div>
+  )
+}

--- a/embuild-analyses/src/components/analyses/vastgoed-verkopen/VastgoedVerkopenEmbed.tsx
+++ b/embuild-analyses/src/components/analyses/vastgoed-verkopen/VastgoedVerkopenEmbed.tsx
@@ -1,0 +1,183 @@
+"use client"
+
+import { useMemo } from "react"
+import { FilterableChart } from "../shared/FilterableChart"
+import { FilterableTable } from "../shared/FilterableTable"
+
+import yearlyRaw from "../../../../analyses/vastgoed-verkopen/results/yearly.json"
+import quarterlyRaw from "../../../../analyses/vastgoed-verkopen/results/quarterly.json"
+
+type YearlyRow = {
+  y: number
+  lvl: number
+  nis: string
+  type: string
+  n: number
+  p50: number
+  name: string
+}
+
+type QuarterlyRow = {
+  y: number
+  q: number
+  lvl: number
+  nis: string
+  type: string
+  n: number
+  p50: number
+  p25: number
+  p75: number
+  name: string
+}
+
+type YearPoint = {
+  sortValue: number
+  periodCells: Array<string | number>
+  value: number
+}
+
+type SectionType = "transacties" | "prijzen" | "transacties-kwartaal" | "prijzen-kwartaal"
+type ViewType = "chart" | "table"
+
+function formatInt(n: number) {
+  return new Intl.NumberFormat("nl-BE", { maximumFractionDigits: 0 }).format(n)
+}
+
+function formatPrice(n: number) {
+  return new Intl.NumberFormat("nl-BE", {
+    style: "currency",
+    currency: "EUR",
+    maximumFractionDigits: 0,
+  }).format(n)
+}
+
+function aggregateTransactionsByYear(rows: YearlyRow[]): YearPoint[] {
+  const agg = new Map<number, number>()
+  for (const r of rows) {
+    if (typeof r.y !== "number" || typeof r.n !== "number") continue
+    agg.set(r.y, (agg.get(r.y) ?? 0) + r.n)
+  }
+  return Array.from(agg.entries())
+    .map(([y, v]) => ({ sortValue: y, periodCells: [y], value: v }))
+    .sort((a, b) => a.sortValue - b.sortValue)
+}
+
+function aggregateMedianPriceByYear(rows: YearlyRow[]): YearPoint[] {
+  const agg = new Map<number, number>()
+  for (const r of rows) {
+    if (typeof r.y !== "number" || typeof r.p50 !== "number") continue
+    agg.set(r.y, r.p50)
+  }
+  return Array.from(agg.entries())
+    .map(([y, v]) => ({ sortValue: y, periodCells: [y], value: v }))
+    .sort((a, b) => a.sortValue - b.sortValue)
+}
+
+function aggregateByQuarter(rows: QuarterlyRow[], metric: "n" | "p50"): YearPoint[] {
+  return rows
+    .filter((r) => typeof r.y === "number" && typeof r.q === "number" && typeof r[metric] === "number")
+    .map((r) => ({
+      sortValue: r.y * 10 + r.q,
+      periodCells: [r.y, `Q${r.q}`],
+      value: r[metric],
+    }))
+    .sort((a, b) => a.sortValue - b.sortValue)
+}
+
+interface VastgoedVerkopenEmbedProps {
+  section: SectionType
+  viewType: ViewType
+  geo?: string | null
+  type?: string | null
+}
+
+export function VastgoedVerkopenEmbed({
+  section,
+  viewType,
+  geo = null,
+  type = "alle_huizen",
+}: VastgoedVerkopenEmbedProps) {
+  const yearlyRows = useMemo(() => yearlyRaw as YearlyRow[], [])
+  const quarterlyRows = useMemo(() => quarterlyRaw as QuarterlyRow[], [])
+
+  // Filter by geo level (Belgium = lvl 1)
+  const filteredYearly = useMemo(() => {
+    let filtered = yearlyRows.filter((r) => r.lvl === 1 && r.type === type)
+    return filtered
+  }, [yearlyRows, type])
+
+  const filteredQuarterly = useMemo(() => {
+    let filtered = quarterlyRows.filter((r) => r.lvl === 1 && r.type === type)
+    return filtered
+  }, [quarterlyRows, type])
+
+  // Compute the appropriate data series based on section
+  const yearSeries = useMemo(() => {
+    switch (section) {
+      case "transacties":
+        return aggregateTransactionsByYear(filteredYearly)
+      case "prijzen":
+        return aggregateMedianPriceByYear(filteredYearly)
+      case "transacties-kwartaal":
+        return aggregateByQuarter(filteredQuarterly, "n")
+      case "prijzen-kwartaal":
+        return aggregateByQuarter(filteredQuarterly, "p50")
+    }
+  }, [section, filteredYearly, filteredQuarterly])
+
+  // Build title
+  const title = useMemo(() => {
+    switch (section) {
+      case "transacties":
+        return "Aantal transacties"
+      case "prijzen":
+        return "Mediaanprijs"
+      case "transacties-kwartaal":
+        return "Transacties per kwartaal"
+      case "prijzen-kwartaal":
+        return "Mediaanprijs per kwartaal"
+    }
+  }, [section])
+
+  const isQuarterly = section.includes("kwartaal")
+  const isPriceMetric = section.includes("prijzen")
+  const label = isPriceMetric ? "Prijs (€)" : "Transacties"
+  const formatValue = isPriceMetric ? formatPrice : formatInt
+  const periodHeaders = isQuarterly ? ["Jaar", "Kwartaal"] : ["Jaar"]
+
+  return (
+    <div className="p-4">
+      <h2 className="text-lg font-semibold mb-4">{title}</h2>
+
+      {viewType === "chart" && (
+        <FilterableChart
+          data={yearSeries}
+          getLabel={(d) =>
+            isQuarterly
+              ? `${(d as YearPoint).periodCells[0]} ${(d as YearPoint).periodCells[1]}`
+              : String((d as YearPoint).periodCells[0])
+          }
+          getValue={(d) => (d as YearPoint).value}
+          getSortValue={(d) => (d as YearPoint).sortValue}
+        />
+      )}
+
+      {viewType === "table" && (
+        <FilterableTable data={yearSeries} label={label} periodHeaders={periodHeaders} />
+      )}
+
+      <div className="mt-4 text-xs text-muted-foreground text-center">
+        <a
+          href={typeof window !== "undefined" ? window.location.origin + (process.env.NODE_ENV === "production" ? "/data-blog" : "") : ""}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline"
+        >
+          Data Blog
+        </a>
+        {" · "}
+        <span>Bron: Statbel</span>
+      </div>
+    </div>
+  )
+}

--- a/embuild-analyses/src/lib/embed-config.ts
+++ b/embuild-analyses/src/lib/embed-config.ts
@@ -92,6 +92,76 @@ export const EMBED_CONFIGS: AnalysisEmbedConfig[] = [
       },
     },
   },
+  {
+    slug: "vastgoed-verkopen",
+    sections: {
+      transacties: {
+        type: "custom",
+        title: "Aantal transacties",
+        component: "VastgoedVerkopenEmbed",
+      },
+      prijzen: {
+        type: "custom",
+        title: "Mediaanprijs",
+        component: "VastgoedVerkopenEmbed",
+      },
+      "transacties-kwartaal": {
+        type: "custom",
+        title: "Transacties per kwartaal",
+        component: "VastgoedVerkopenEmbed",
+      },
+      "prijzen-kwartaal": {
+        type: "custom",
+        title: "Mediaanprijs per kwartaal",
+        component: "VastgoedVerkopenEmbed",
+      },
+    },
+  },
+  {
+    slug: "faillissementen",
+    sections: {
+      evolutie: {
+        type: "custom",
+        title: "Evolutie faillissementen",
+        component: "FaillissementenEmbed",
+      },
+      leeftijd: {
+        type: "custom",
+        title: "Bedrijfsleeftijd",
+        component: "FaillissementenEmbed",
+      },
+      bedrijfsgrootte: {
+        type: "custom",
+        title: "Bedrijfsgrootte",
+        component: "FaillissementenEmbed",
+      },
+      sectoren: {
+        type: "custom",
+        title: "Sectorvergelijking",
+        component: "FaillissementenEmbed",
+      },
+    },
+  },
+  {
+    slug: "huishoudensgroei",
+    sections: {
+      evolutie: {
+        type: "custom",
+        title: "Evolutie aantal huishoudens",
+        component: "HuishoudensgroeiEmbed",
+      },
+      ranking: {
+        type: "custom",
+        title: "Gemeenten ranking",
+        component: "HuishoudensgroeiEmbed",
+      },
+      "size-breakdown": {
+        type: "custom",
+        title: "Samenstelling huishoudens",
+        component: "HuishoudensgroeiEmbed",
+      },
+    },
+  },
 ]
 
 /**


### PR DESCRIPTION
Fixes #51

Adds iframe embed support for the 3 remaining analyses that had ExportButtons but no embed functionality.

### Changes

- Created VastgoedVerkopenEmbed.tsx for 4 sections
- Created FaillissementenEmbed.tsx for 4 sections
- Created HuishoudensgroeiEmbed.tsx for 3 sections
- Registered all 11 sections in embed-config.ts
- Updated EmbedClient.tsx to handle new components

### Result

All 6 analyses now have complete embed support for a total of 16 embeddable sections.

Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/gehuybre/data-blog/actions/runs/20544548567) • [Branch](https://github.com/gehuybre/data-blog/tree/claude/issue-51-20251227-2123