### PR TITLE
Fix bankruptcies data source to include all Belgian provinces

### DIFF
--- a/embuild-analyses/analyses/faillissementen/content.mdx
+++ b/embuild-analyses/analyses/faillissementen/content.mdx
@@ -1,7 +1,7 @@
 ---
 title: Faillissementen in de bouwsector
 date: 2023-11-01
-summary: Maandelijkse evolutie van faillissementen in de Vlaamse bouwsector, met vergelijking met andere sectoren en regionale spreiding.
+summary: Maandelijkse evolutie van faillissementen in de Belgische bouwsector, met vergelijking met andere sectoren en regionale spreiding.
 tags: [economie, bedrijven, bouw, faillissementen]
 slug: faillissementen
 sourceProvider: Statbel

--- a/embuild-analyses/analyses/faillissementen/src/process_faillissementen.py
+++ b/embuild-analyses/analyses/faillissementen/src/process_faillissementen.py
@@ -74,11 +74,9 @@ def download_data() -> pd.DataFrame:
         print(f"Using INPUT_URL: {input_url}")
         urls_to_try = [input_url]
     else:
-        # Try current year, then previous year
-        current_year = datetime.now().year
+        # Use the static Statbel URL (no year parameter needed)
         urls_to_try = [
-            f"{BASE_URL}/TF_BANKRUPTCIES({current_year}).zip",
-            f"{BASE_URL}/TF_BANKRUPTCIES({current_year - 1}).zip",
+            f"{BASE_URL}/TF_BANKRUPTCIES.zip",
         ]
 
     for url in urls_to_try:
@@ -258,7 +256,7 @@ def process_data(df: pd.DataFrame) -> None:
         json.dump(monthly_sector_json, f)
 
     # =========================================================================
-    # AGGREGATE 7: By province (Flemish provinces only, construction sector)
+    # AGGREGATE 7: By province (construction sector)
     # =========================================================================
     df_bouw_prov = df_bouw[df_bouw["CD_PROV_REFNIS"].notna()].copy()
     df_bouw_prov["CD_PROV_REFNIS"] = df_bouw_prov["CD_PROV_REFNIS"].astype(int)


### PR DESCRIPTION
Fixed the data source URL to use the static Statbel URL that contains data for all 11 Belgian provinces.

## Changes
- Updated Python processing script to use `TF_BANKRUPTCIES.zip` instead of `TF_BANKRUPTCIES(YEAR).zip`
- Changed blog post summary from "Vlaamse" to "Belgische" bouwsector
- Removed misleading comment about Flemish provinces only

## Note
The GitHub Actions workflow also needs updating (cannot be modified due to permissions). After merging, please update `.github/workflows/update-faillissementen-data.yml` to use the static URL.

Fixes #52

Generated with [Claude Code](https://claude.ai/code)