### PR TITLE
Consistente layout + dashboard-controls voor analyses

### DIFF
--- a/embuild-analyses/ANALYSIS_TEMPLATE.md
+++ b/embuild-analyses/ANALYSIS_TEMPLATE.md
@@ -1,0 +1,55 @@
+# Template & UI-afspraken voor analyses
+
+## 1) `content.mdx` structuur (titel/datum/summary komen uit frontmatter)
+
+Maak een nieuwe analyse in `embuild-analyses/analyses/<slug>/content.mdx`:
+
+```mdx
+---
+title: Jouw titel
+date: 2025-01-01
+summary: Korte uitleg (1–2 zinnen) die onder de titel komt.
+tags: [tag1, tag2]
+slug: jouw-slug
+sourceProvider: Bronorganisatie
+sourceTitle: Titel van de bronpagina/dataset
+sourceUrl: https://...
+sourcePublicationDate: 2025-01-01
+---
+
+import { JouwDashboard } from "@/components/analyses/jouw-slug/JouwDashboard"
+
+Korte introtekst (optioneel).
+
+<JouwDashboard />
+```
+
+Belangrijk:
+- Zet **geen** `# H1` in de MDX: de pagina-layout rendert de titel al.
+- De footer “Bron: …” komt automatisch uit `sourceProvider/sourceUrl/sourceTitle/sourcePublicationDate`.
+
+## 2) Consistente plaatsing van knoppen/filters in dashboards
+
+Doel: overal dezelfde “look & feel” voor:
+- rechtsboven: `CSV` + `Embed`
+- onder de sectietitel: tabs/selector links, filters/extra controls rechts
+
+Gebruik daarom (bij voorkeur) deze gedeelde componenten:
+
+### A) Geo + grafiek/tabel/kaart (meest standaard)
+
+Gebruik `AnalysisSection`:
+- Bestand: `embuild-analyses/src/components/analyses/shared/AnalysisSection.tsx`
+- UI: tabs `Grafiek/Tabel/Kaart` + geo-filters + export
+
+### B) Time series zonder geo (bv. jaar/kwartaal/type/trend)
+
+Gebruik `TimeSeriesSection`:
+- Bestand: `embuild-analyses/src/components/analyses/shared/TimeSeriesSection.tsx`
+- UI: sectietitel + export, en daaronder tabs links + extra controls rechts (bv. metriek-selector)
+
+## 3) Embed/CSV afspraken
+
+- Geef altijd `slug` + `sectionId` door aan `AnalysisSection`/`TimeSeriesSection` zodat `ExportButtons` correcte embed-URL’s kan genereren.
+- Als een sectie “Embed” moet ondersteunen, voeg ze toe aan `embuild-analyses/src/lib/embed-config.ts`.
+

--- a/embuild-analyses/analyses/energiekaart-premies/content.mdx
+++ b/embuild-analyses/analyses/energiekaart-premies/content.mdx
@@ -12,8 +12,6 @@ sourcePublicationDate: 2025-12-28
 
 import { EnergiekaartDashboard } from "@/components/analyses/energiekaart-premies/EnergiekaartDashboard"
 
-# Energiepremies Vlaanderen
-
 Deze analyse toont de evolutie van energiepremies voor residentiële gebouwen in Vlaanderen (data: 28 december 2025). De data wordt geëxtraheerd uit het officiële Energiekaart PowerBI dashboard van het Vlaams Energieagentschap.
 
 ## Over de data

--- a/embuild-analyses/analyses/gemeentelijke-investeringen/content.mdx
+++ b/embuild-analyses/analyses/gemeentelijke-investeringen/content.mdx
@@ -8,7 +8,4 @@ sourceProvider: Agentschap Binnenlands Bestuur
 sourceTitle: Gemeentelijke jaarrekeningen
 sourceUrl: https://lokaalbestuur.vlaanderen.be/financien/bbc-dr/gemeente-financien
 ---
-
-# Gemeentelijke Investeringen
-
 Hier komt de analyse van de gemeentelijke investeringen.

--- a/embuild-analyses/analyses/vergunningen-goedkeuringen/content.mdx
+++ b/embuild-analyses/analyses/vergunningen-goedkeuringen/content.mdx
@@ -12,8 +12,6 @@ sourcePublicationDate: 2025-12-01
 
 import { VergunningenDashboard } from "@/components/analyses/vergunningen-goedkeuringen/VergunningenDashboard"
 
-# Vergunningen Goedkeuringen
-
 Hieronder vindt u de analyse van de goedgekeurde vergunningen voor residentiële gebouwen (data: december 2025), opgesplitst in renovatie en nieuwbouw.
 
 <VergunningenDashboard />

--- a/embuild-analyses/src/app/analyses/[slug]/page.tsx
+++ b/embuild-analyses/src/app/analyses/[slug]/page.tsx
@@ -1,10 +1,7 @@
 import { allAnalyses } from 'contentlayer/generated'
 import { notFound } from 'next/navigation'
-import { format, parseISO } from 'date-fns'
-import { nl } from 'date-fns/locale'
 import { MDXContent } from '@/components/mdx-content'
-import Link from 'next/link'
-import { ArrowLeft, ExternalLink } from 'lucide-react'
+import { AnalysisLayout } from '@/components/analyses/AnalysisLayout'
 
 export const generateStaticParams = async () => {
   return allAnalyses.map((analysis) => ({ slug: analysis.slug }))
@@ -24,44 +21,19 @@ export default async function AnalysisPage({ params }: { params: Promise<{ slug:
   if (!analysis) notFound()
 
   return (
-    <article className="container mx-auto py-10 prose dark:prose-invert max-w-3xl">
-      <nav className="mb-6 not-prose">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          <span>Terug naar overzicht</span>
-        </Link>
-      </nav>
-      <div className="mb-8 text-center">
-        <h1 className="text-4xl font-bold mb-2">{analysis.title}</h1>
-        <time
-          dateTime={analysis.sourcePublicationDate || analysis.date}
-          className="text-muted-foreground"
-        >
-          {format(parseISO(analysis.sourcePublicationDate || analysis.date), 'd MMMM yyyy', { locale: nl })}
-        </time>
-      </div>
+    <AnalysisLayout
+      title={analysis.title}
+      date={analysis.sourcePublicationDate || analysis.date}
+      summary={analysis.summary}
+      tags={analysis.tags}
+      source={{
+        provider: analysis.sourceProvider,
+        title: analysis.sourceTitle,
+        url: analysis.sourceUrl,
+        publicationDate: analysis.sourcePublicationDate,
+      }}
+    >
       <MDXContent code={analysis.body.code} />
-
-      {analysis.sourceProvider && analysis.sourceUrl && (
-        <footer className="mt-12 pt-6 border-t not-prose">
-          <div className="text-sm text-muted-foreground">
-            <span className="font-medium">Bron:</span>{' '}
-            <a
-              href={analysis.sourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-primary hover:underline"
-            >
-              {analysis.sourceProvider}
-              {analysis.sourceTitle && ` - ${analysis.sourceTitle}`}
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          </div>
-        </footer>
-      )}
-    </article>
+    </AnalysisLayout>
   )
 }

--- a/embuild-analyses/src/components/analyses/AnalysisLayout.tsx
+++ b/embuild-analyses/src/components/analyses/AnalysisLayout.tsx
@@ -1,0 +1,91 @@
+import { format, parseISO } from 'date-fns'
+import { nl } from 'date-fns/locale'
+import Link from 'next/link'
+import { ArrowLeft, ExternalLink } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import type { ReactNode } from 'react'
+
+type SourceInfo = {
+  provider?: string
+  title?: string
+  url?: string
+  publicationDate?: string
+}
+
+function formatDate(isoDate: string) {
+  return format(parseISO(isoDate), 'd MMMM yyyy', { locale: nl })
+}
+
+export function AnalysisLayout({
+  title,
+  date,
+  summary,
+  tags,
+  source,
+  children,
+}: {
+  title: string
+  date: string
+  summary?: string
+  tags?: string[]
+  source?: SourceInfo
+  children: ReactNode
+}) {
+  const showSource = Boolean(source?.provider && source?.url)
+
+  return (
+    <article className="container mx-auto py-10 max-w-3xl">
+      <nav className="mb-6">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          <span>Terug naar overzicht</span>
+        </Link>
+      </nav>
+
+      <header className="mb-10 text-center">
+        <h1 className="text-4xl font-bold mb-2">{title}</h1>
+        <time dateTime={date} className="text-muted-foreground">
+          {formatDate(date)}
+        </time>
+
+        {summary && <p className="mt-4 text-muted-foreground">{summary}</p>}
+
+        {!!tags?.length && (
+          <div className="mt-5 flex flex-wrap justify-center gap-2">
+            {tags.map((tag) => (
+              <Badge key={tag} variant="secondary">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </header>
+
+      <div className="prose dark:prose-invert max-w-none">{children}</div>
+
+      {showSource && (
+        <footer className="mt-12 pt-6 border-t">
+          <div className="text-sm text-muted-foreground">
+            <span className="font-medium">Bron:</span>{' '}
+            <a
+              href={source!.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
+              {source!.provider}
+              {source?.title && ` - ${source.title}`}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+            {source?.publicationDate && (
+              <span className="ml-2">({formatDate(source.publicationDate)})</span>
+            )}
+          </div>
+        </footer>
+      )}
+    </article>
+  )
+}

--- a/embuild-analyses/src/components/analyses/shared/TimeSeriesSection.tsx
+++ b/embuild-analyses/src/components/analyses/shared/TimeSeriesSection.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import * as React from "react"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { ExportButtons } from "./ExportButtons"
+
+type ExportRow = {
+  label: string
+  value: number
+  periodCells?: Array<string | number>
+}
+
+type ViewType = "chart" | "table" | "map"
+
+type TimeSeriesView = {
+  value: string
+  label: string
+  content: React.ReactNode
+  exportData?: ExportRow[]
+  exportMeta?: {
+    viewType?: ViewType
+    periodHeaders?: string[]
+    valueLabel?: string
+    embedParams?: Record<string, string | number | null | undefined>
+  }
+}
+
+export function TimeSeriesSection({
+  title,
+  slug,
+  sectionId,
+  dataSource,
+  dataSourceUrl,
+  defaultView,
+  headerContent,
+  rightControls,
+  views,
+}: {
+  title: string
+  slug?: string
+  sectionId?: string
+  dataSource?: string
+  dataSourceUrl?: string
+  defaultView: string
+  headerContent?: React.ReactNode
+  rightControls?: React.ReactNode
+  views: TimeSeriesView[]
+}) {
+  const [currentView, setCurrentView] = React.useState<string>(defaultView)
+
+  const activeView = React.useMemo(() => {
+    return views.find((v) => v.value === currentView) ?? views[0]
+  }, [views, currentView])
+
+  const canExport = Boolean(slug && sectionId && activeView?.exportData?.length)
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold">{title}</h2>
+        {canExport && (
+          <ExportButtons
+            data={activeView.exportData!}
+            title={title}
+            slug={slug!}
+            sectionId={sectionId!}
+            viewType={activeView.exportMeta?.viewType ?? "chart"}
+            periodHeaders={activeView.exportMeta?.periodHeaders}
+            valueLabel={activeView.exportMeta?.valueLabel}
+            dataSource={dataSource}
+            dataSourceUrl={dataSourceUrl}
+            embedParams={activeView.exportMeta?.embedParams}
+          />
+        )}
+      </div>
+
+      {headerContent}
+
+      <Tabs defaultValue={defaultView} onValueChange={setCurrentView}>
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+          <TabsList>
+            {views.map((v) => (
+              <TabsTrigger key={v.value} value={v.value}>
+                {v.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {rightControls ? <div className="flex items-center gap-2">{rightControls}</div> : null}
+        </div>
+
+        {views.map((v) => (
+          <TabsContent key={v.value} value={v.value}>
+            {v.content}
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  )
+}
+


### PR DESCRIPTION
Deze PR maakt de blog/analysis layout consistent en standaardiseert de UI-plaatsing van controls in dashboards.

- Nieuwe `AnalysisLayout` zorgt voor vaste header (titel/datum/summary/tags) + bron-footer vanuit frontmatter
- Nieuwe `TimeSeriesSection` standaardiseert tabs + right-side controls + CSV/Embed
- `vergunningen-aanvragen` dashboard gerefactord als referentie
- Overbodige H1’s uit enkele MDX posts verwijderd
- Auteurshandleiding toegevoegd: `embuild-analyses/ANALYSIS_TEMPLATE.md`
