### PR TITLE
Blog post compliance: frontmatter, footers, and TypeScript fixes

### DIFF
--- a/embuild-analyses/analyses/faillissementen/content.mdx
+++ b/embuild-analyses/analyses/faillissementen/content.mdx
@@ -12,10 +12,6 @@ sourcePublicationDate: 2024-12-19
 
 import { FaillissementenDashboard } from "@/components/analyses/faillissementen/FaillissementenDashboard"
 
+Deze analyse is gebaseerd op data van 19 december 2024.
+
 <FaillissementenDashboard />
-
----
-
-### Bron
-
-De data voor deze analyse komt van [Statbel - Maandelijkse faillissementen per activiteitssector](https://statbel.fgov.be/nl/themas/ondernemingen/faillissementen/maandelijkse-faillissementen). Laatste update: 19 december 2024.

--- a/embuild-analyses/analyses/gemeentelijke-investeringen/content.mdx
+++ b/embuild-analyses/analyses/gemeentelijke-investeringen/content.mdx
@@ -7,5 +7,6 @@ slug: gemeentelijke-investeringen
 sourceProvider: Agentschap Binnenlands Bestuur
 sourceTitle: Gemeentelijke jaarrekeningen
 sourceUrl: https://lokaalbestuur.vlaanderen.be/financien/bbc-dr/gemeente-financien
+sourcePublicationDate: 2023-10-28
 ---
 Hier komt de analyse van de gemeentelijke investeringen.

--- a/embuild-analyses/analyses/huishoudensgroei/content.mdx
+++ b/embuild-analyses/analyses/huishoudensgroei/content.mdx
@@ -7,6 +7,7 @@ slug: huishoudensgroei
 sourceProvider: Statistiek Vlaanderen
 sourceTitle: Huishoudensvooruitzichten - aantal en groei
 sourceUrl: https://www.vlaanderen.be/statistiek-vlaanderen/bevolking/huishoudensvooruitzichten-aantal-en-groei
+sourcePublicationDate: 2024-05-21
 ---
 
 import { HuishoudensDashboard } from "@/components/analyses/huishoudensgroei/HuishoudensDashboard"

--- a/embuild-analyses/analyses/prijsherziening-index-i-2021/content.mdx
+++ b/embuild-analyses/analyses/prijsherziening-index-i-2021/content.mdx
@@ -10,7 +10,7 @@ sourceUrl: https://economie.fgov.be/nl/themas/ondernemingen/specifieke-sectoren/
 sourcePublicationDate: 2025-01-30
 ---
 
-import { PrijsherzieningDashboard } from "../../src/components/analyses/prijsherziening/PrijsherzieningDashboard"
+import { PrijsherzieningDashboard } from "@/components/analyses/prijsherziening/PrijsherzieningDashboard"
 
 De prijsherzieningsindex I 2021 is een officiële index die wordt gebruikt om contractprijzen in de bouwsector aan te passen aan de evolutie van materiaal- en loonkosten. Deze index is vooral relevant voor langlopende bouwcontracten waarbij prijsschommelingen van grondstoffen en arbeid kunnen worden doorgerekend.
 
@@ -46,13 +46,3 @@ De index I 2021 bestaat uit meerdere componenten die de evolutie van verschillen
 - **Lonen**: arbeidskosten in de bouwsector
 
 <PrijsherzieningDashboard />
-
----
-
-### Bron
-
-De data voor deze analyse komt van [FOD Economie - Prijsherzieningsindexen Mercuriale Index I 2021](https://economie.fgov.be/nl/themas/ondernemingen/specifieke-sectoren/bouw/prijsherzieningsindexen/mercuriale-index-i-2021).
-
-**Methodologie**: [Hervorming van de Mercuriale - Methodologische Nota](https://economie.fgov.be/sites/default/files/Files/Entreprises/Hervorming-van-de-Mercuriale-Methodologische-Nota.pdf)
-
-**Toepassing**: [Hoe de index I 2021 toepassen in een prijsherzieningsformule](https://economie.fgov.be/sites/default/files/Files/Entreprises/Mercuriale-Hoe-de-index-I-2021-toepassen-in-een-prijsherzieningsformule.pdf)

--- a/embuild-analyses/analyses/vergunningen-goedkeuringen/content.mdx
+++ b/embuild-analyses/analyses/vergunningen-goedkeuringen/content.mdx
@@ -15,9 +15,3 @@ import { VergunningenDashboard } from "@/components/analyses/vergunningen-goedke
 Hieronder vindt u de analyse van de goedgekeurde vergunningen voor residentiële gebouwen (data: december 2025), opgesplitst in renovatie en nieuwbouw.
 
 <VergunningenDashboard />
-
----
-
-## Databron
-
-De gegevens in deze analyse zijn afkomstig van [Statbel - Bouwvergunningen per gemeente](https://statbel.fgov.be/nl/themas/bouwen-wonen/bouwvergunningen) (gepubliceerd: december 2025).

--- a/embuild-analyses/src/components/analyses/energiekaart-premies/EnergiekaartChart.tsx
+++ b/embuild-analyses/src/components/analyses/energiekaart-premies/EnergiekaartChart.tsx
@@ -58,7 +58,7 @@ export function EnergiekaartChart({ data, label, isCurrency = false }: Energieka
         />
         <YAxis tickFormatter={formatValue} style={{ fontSize: "0.875rem" }} />
         <Tooltip
-          formatter={(value: number) => formatValue(value)}
+          formatter={(value: number | undefined) => value !== undefined ? formatValue(value) : ""}
           labelFormatter={(jaar) => `Jaar: ${jaar}`}
           contentStyle={{
             backgroundColor: "hsl(var(--card))",

--- a/embuild-analyses/src/components/analyses/vergunningen-aanvragen/VergunningenDashboard.tsx
+++ b/embuild-analyses/src/components/analyses/vergunningen-aanvragen/VergunningenDashboard.tsx
@@ -264,7 +264,7 @@ function NieuwbouwSection() {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="jaar" />
                     <YAxis tickFormatter={formatInt} />
-                    <Tooltip formatter={(v: number) => formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined) => v !== undefined ? formatInt(v) : ""} />
                     <Bar dataKey="waarde" name={METRIC_LABELS[metric]} fill="#3b82f6" />
                   </BarChart>
                 </ResponsiveContainer>
@@ -286,7 +286,7 @@ function NieuwbouwSection() {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="label" tick={{ fontSize: 10 }} interval={3} />
                     <YAxis tickFormatter={formatInt} />
-                    <Tooltip formatter={(v: number) => formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined) => v !== undefined ? formatInt(v) : ""} />
                     <Area type="monotone" dataKey="waarde" name={METRIC_LABELS[metric]} fill="#3b82f6" stroke="#2563eb" />
                   </AreaChart>
                 </ResponsiveContainer>
@@ -308,7 +308,7 @@ function NieuwbouwSection() {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="jaar" />
                     <YAxis tickFormatter={formatInt} />
-                    <Tooltip formatter={(v: number) => formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined) => v !== undefined ? formatInt(v) : ""} />
                     <Legend />
                     <Bar dataKey="Eengezinswoning" fill={TYPE_COLORS.eengezins} />
                     <Bar dataKey="Meergezinswoning" fill={TYPE_COLORS.meergezins} />
@@ -334,7 +334,7 @@ function NieuwbouwSection() {
                     <XAxis dataKey="jaar" />
                     <YAxis yAxisId="left" tickFormatter={formatInt} />
                     <YAxis yAxisId="right" orientation="right" domain={[0, 150]} />
-                    <Tooltip formatter={(v: number, name: string) => name === "Index" ? v.toFixed(1) : formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined, name: string | undefined) => v !== undefined ? (name === "Index" ? v.toFixed(1) : formatInt(v)) : ""} />
                     <Legend />
                     <Bar yAxisId="left" dataKey="waarde" name={METRIC_LABELS[metric]} fill="#3b82f6" />
                     <Line yAxisId="right" type="monotone" dataKey="index" name="Index" stroke="#ef4444" strokeWidth={2} dot={{ r: 3 }} />
@@ -467,7 +467,7 @@ function VerbouwSection() {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="jaar" />
                     <YAxis tickFormatter={formatInt} />
-                    <Tooltip formatter={(v: number) => formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined) => v !== undefined ? formatInt(v) : ""} />
                     <Bar dataKey="waarde" name={METRIC_LABELS[metric]} fill="#22c55e" />
                   </BarChart>
                 </ResponsiveContainer>
@@ -489,7 +489,7 @@ function VerbouwSection() {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="label" tick={{ fontSize: 10 }} interval={3} />
                     <YAxis tickFormatter={formatInt} />
-                    <Tooltip formatter={(v: number) => formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined) => v !== undefined ? formatInt(v) : ""} />
                     <Area type="monotone" dataKey="waarde" name={METRIC_LABELS[metric]} fill="#22c55e" stroke="#16a34a" />
                   </AreaChart>
                 </ResponsiveContainer>
@@ -511,7 +511,7 @@ function VerbouwSection() {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="jaar" />
                     <YAxis tickFormatter={formatInt} />
-                    <Tooltip formatter={(v: number) => formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined) => v !== undefined ? formatInt(v) : ""} />
                     <Legend />
                     <Bar dataKey="Eengezinswoning" fill={TYPE_COLORS.eengezins} />
                     <Bar dataKey="Meergezinswoning" fill={TYPE_COLORS.meergezins} />
@@ -537,7 +537,7 @@ function VerbouwSection() {
                     <XAxis dataKey="jaar" />
                     <YAxis yAxisId="left" tickFormatter={formatInt} />
                     <YAxis yAxisId="right" orientation="right" domain={[0, 150]} />
-                    <Tooltip formatter={(v: number, name: string) => name === "Index" ? v.toFixed(1) : formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined, name: string | undefined) => v !== undefined ? (name === "Index" ? v.toFixed(1) : formatInt(v)) : ""} />
                     <Legend />
                     <Bar yAxisId="left" dataKey="waarde" name={METRIC_LABELS[metric]} fill="#22c55e" />
                     <Line yAxisId="right" type="monotone" dataKey="index" name="Index" stroke="#ef4444" strokeWidth={2} dot={{ r: 3 }} />
@@ -672,7 +672,7 @@ function SloopSection() {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="jaar" />
                     <YAxis tickFormatter={formatInt} />
-                    <Tooltip formatter={(v: number) => formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined) => v !== undefined ? formatInt(v) : ""} />
                     <Bar dataKey="waarde" name={SLOOP_METRIC_LABELS[metric]} fill="#ef4444" />
                   </BarChart>
                 </ResponsiveContainer>
@@ -694,7 +694,7 @@ function SloopSection() {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="label" tick={{ fontSize: 10 }} interval={3} />
                     <YAxis tickFormatter={formatInt} />
-                    <Tooltip formatter={(v: number) => formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined) => v !== undefined ? formatInt(v) : ""} />
                     <Area type="monotone" dataKey="waarde" name={SLOOP_METRIC_LABELS[metric]} fill="#ef4444" stroke="#dc2626" />
                   </AreaChart>
                 </ResponsiveContainer>
@@ -716,7 +716,7 @@ function SloopSection() {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="jaar" />
                     <YAxis tickFormatter={formatInt} />
-                    <Tooltip formatter={(v: number) => formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined) => v !== undefined ? formatInt(v) : ""} />
                     <Legend />
                     <Bar dataKey="Gemeente" fill="#3b82f6" stackId="a" />
                     <Bar dataKey="Provincie" fill="#22c55e" stackId="a" />
@@ -742,7 +742,7 @@ function SloopSection() {
                     <XAxis dataKey="jaar" />
                     <YAxis yAxisId="left" tickFormatter={formatInt} />
                     <YAxis yAxisId="right" orientation="right" domain={[0, 150]} />
-                    <Tooltip formatter={(v: number, name: string) => name === "Index" ? v.toFixed(1) : formatInt(v)} />
+                    <Tooltip formatter={(v: number | undefined, name: string | undefined) => v !== undefined ? (name === "Index" ? v.toFixed(1) : formatInt(v)) : ""} />
                     <Legend />
                     <Bar yAxisId="left" dataKey="waarde" name={SLOOP_METRIC_LABELS[metric]} fill="#ef4444" />
                     <Line yAxisId="right" type="monotone" dataKey="index" name="Index" stroke="#f59e0b" strokeWidth={2} dot={{ r: 3 }} />


### PR DESCRIPTION
## Summary

This PR brings all 9 blog posts into compliance with the requirements defined in CLAUDE.md:
- ✅ Complete frontmatter with all source fields
- ✅ Automatic footer generation (removed manual footers)
- ✅ Data date mentions where appropriate
- ✅ Absolute imports with @/ prefix
- ✅ TypeScript fixes for build success

## Changes

### Phase 1: Content Compliance

**Frontmatter fixes:**
- `huishoudensgroei`: Added `sourcePublicationDate: 2024-05-21`
- `gemeentelijke-investeringen`: Added `sourcePublicationDate: 2023-10-28`

**Import path fixes:**
- `prijsherziening-index-i-2021`: Changed relative import to `@/` alias

**Manual footer removal** (now automatic via frontmatter):
- `vergunningen-goedkeuringen`: Removed manual "Databron" section
- `faillissementen`: Removed manual "Bron" section + added data date mention
- `prijsherziening-index-i-2021`: Removed manual "Bron" section with methodology links

### Phase 2: Dashboard Assessment

Reviewed all existing dashboard implementations:
- **huishoudensgroei** ✅ - Custom multi-section dashboard with horizon filters
- **starters-stoppers** ✅ - Custom triple-metric dashboard with sector/geo filters
- **vastgoed-verkopen** ✅ - Custom dashboard with property type + multi-level geo
- **faillissementen** ✅ - Custom dashboard with multiple data views
- **prijsherziening** ✅ - Custom dashboard with price calculator
- **energiekaart-premies** ✅ - Already compliant
- **vergunningen-goedkeuringen** ✅ - Already compliant
- **vergunningen-aanvragen** ✅ - Already compliant

All dashboards are properly implemented and exceed the capabilities of standard sections. No migrations needed.

### Phase 3: TypeScript Fixes

Fixed Recharts `Tooltip` formatter types to handle undefined values:
- `EnergiekaartChart.tsx` (1 fix): `value` parameter can be undefined
- `VergunningenDashboard.tsx` (12 fixes): `value` and `name` parameters can be undefined

## Testing

- ✅ `npm run lint` - No errors
- ✅ `npm run build` - Build succeeded
  - 37 static pages generated
  - All embed configurations validated
  - No TypeScript errors

## Files Changed

```
embuild-analyses/analyses/faillissementen/content.mdx               | 8 ++------
embuild-analyses/analyses/gemeentelijke-investeringen/content.mdx  | 1 +
embuild-analyses/analyses/huishoudensgroei/content.mdx             | 1 +
embuild-analyses/analyses/prijsherziening-index-i-2021/content.mdx | 12 +---------
embuild-analyses/analyses/vergunningen-goedkeuringen/content.mdx   | 6 ------
embuild-analyses/src/components/.../EnergiekaartChart.tsx          | 2 +-
embuild-analyses/src/components/.../VergunningenDashboard.tsx      | 24 +++++++++-----------
```

**Total**: 7 files, 18 insertions(+), 36 deletions(-)

## Compliance Status

| Blog Post | Frontmatter | Footer | Data Date | Imports | Status |
|-----------|-------------|---------|-----------|---------|--------|
| energiekaart-premies | ✅ | ✅ | ✅ | ✅ | ✅ Compliant |
| vergunningen-goedkeuringen | ✅ | ✅ | ✅ | ✅ | ✅ Compliant |
| vergunningen-aanvragen | ✅ | ✅ | ✅ | ✅ | ✅ Compliant |
| faillissementen | ✅ | ✅ | ✅ | ✅ | ✅ Compliant |
| huishoudensgroei | ✅ | ✅ | ✅ | ✅ | ✅ Compliant |
| prijsherziening-index-i-2021 | ✅ | ✅ | ✅ | ✅ | ✅ Compliant |
| starters-stoppers | ✅ | ✅ | ✅ | ✅ | ✅ Compliant |
| vastgoed-verkopen | ✅ | ✅ | ✅ | ✅ | ✅ Compliant |
| gemeentelijke-investeringen | ✅ | ✅ | N/A | ✅ | ✅ Compliant |

🤖 Generated with [Claude Code](https://claude.com/claude-code)