### PR TITLE
fix: repair malformed frontmatter in vergunningen-goedkeuringen

### DIFF
--- a/embuild-analyses/analyses/vergunningen-goedkeuringen/content.mdx
+++ b/embuild-analyses/analyses/vergunningen-goedkeuringen/content.mdx
@@ -7,7 +7,8 @@ slug: vergunningen-goedkeuringen
 sourceProvider: Statbel
 sourceTitle: Bouwvergunningen per gemeente
 sourceUrl: https://statbel.fgov.be/nl/themas/bouwen-wonen/bouwvergunningen
-sourcePublicationDate: 2026-01-08---
+sourcePublicationDate: 2026-01-08
+---
 
 import { VergunningenDashboard } from "@/components/analyses/vergunningen-goedkeuringen/VergunningenDashboard"
 

--- a/scripts/update_publication_date.py
+++ b/scripts/update_publication_date.py
@@ -101,11 +101,13 @@ def update_mdx_frontmatter(mdx_path: Path, publication_date: str) -> bool:
     else:
         # Add new field after sourceUrl if it exists, otherwise at the end
         if 'sourceUrl:' in frontmatter:
+            # Ensure frontmatter ends with newline before adding new field
+            frontmatter_lines = frontmatter.rstrip('\n')
             new_frontmatter = re.sub(
                 r'(sourceUrl:\s*[^\n]+)',
                 rf'\1\nsourcePublicationDate: {publication_date}',
-                frontmatter
-            )
+                frontmatter_lines
+            ) + '\n'
         else:
             # Add at end of frontmatter (ensure newline)
             new_frontmatter = frontmatter.rstrip('\n') + f'\nsourcePublicationDate: {publication_date}\n'


### PR DESCRIPTION
## Summary
- Fixed malformed YAML frontmatter in `vergunningen-goedkeuringen/content.mdx` where `sourcePublicationDate` was concatenated with closing `---`
- Updated `update_publication_date.py` to ensure proper newline handling when adding publication date fields

This fixes issue #118 where the blog post was not visible due to Contentlayer failing to parse the frontmatter.

🤖 Generated with [Claude Code](https://claude.ai/code)