### PR TITLE
fix: correct MunicipalityData type to match Municipality interface

### DIFF
--- a/embuild-analyses/src/components/analyses/vergunningen-goedkeuringen/VergunningenDashboard.tsx
+++ b/embuild-analyses/src/components/analyses/vergunningen-goedkeuringen/VergunningenDashboard.tsx
@@ -16,7 +16,7 @@ type DataRow = {
 }
 
 type MunicipalityData = {
-  m: number
+  code: number
   name: string
 }
 


### PR DESCRIPTION
Fixes #137

Changed MunicipalityData type to use 'code' instead of 'm' to match the Municipality interface from geo-utils and the actual data structure in municipalities.json.

This resolves the TypeScript compilation error that was preventing the build from succeeding.

Generated with [Claude Code](https://claude.ai/code)