### PR TITLE
Remove emoticons from bouwprojecten-gemeenten

### DIFF
--- a/embuild-analyses/analyses/bouwprojecten-gemeenten/content.mdx
+++ b/embuild-analyses/analyses/bouwprojecten-gemeenten/content.mdx
@@ -39,16 +39,16 @@ Gebruik de filters om relevante projecten te vinden:
 
 Projecten zijn automatisch ingedeeld in 10 bouwsectoren op basis van projectbeschrijvingen:
 
-- 🛣️ **Wegenbouw** (1,390 projecten) - Wegen, straten, fietspaden, bruggen
-- 🌳 **Groen** (940 projecten) - Parks, natuurgebieden, recreatie
-- ♿ **Zorg** (734 projecten) - Woonzorgcentra, rusthuizen, kinderopvang
-- 💧 **Riolering** (449 projecten) - Riolering, afvalwater, drainage
-- 🏫 **Scholenbouw** (384 projecten) - Scholen, kleuterscholen, leslokalen
-- 🏢 **Gebouwen** (377 projecten) - Gemeentehuizen, administratieve centra
-- ⚽ **Sport** (359 projecten) - Sportzalen, voetbalvelden, zwembaden
-- 🎭 **Cultuur** (287 projecten) - Bibliotheken, gemeenschapscentra, musea
-- 💡 **Verlichting** (250 projecten) - Straatverlichting, verkeerslichten
-- 🏘️ **Ruimtelijke ordening** (177 projecten) - Herinrichting, gebiedsontwikkeling
+- **Wegenbouw** (1,390 projecten) - Wegen, straten, fietspaden, bruggen
+- **Groen** (940 projecten) - Parks, natuurgebieden, recreatie
+- **Zorg** (734 projecten) - Woonzorgcentra, rusthuizen, kinderopvang
+- **Riolering** (449 projecten) - Riolering, afvalwater, drainage
+- **Scholenbouw** (384 projecten) - Scholen, kleuterscholen, leslokalen
+- **Gebouwen** (377 projecten) - Gemeentehuizen, administratieve centra
+- **Sport** (359 projecten) - Sportzalen, voetbalvelden, zwembaden
+- **Cultuur** (287 projecten) - Bibliotheken, gemeenschapscentra, musea
+- **Verlichting** (250 projecten) - Straatverlichting, verkeerslichten
+- **Ruimtelijke ordening** (177 projecten) - Herinrichting, gebiedsontwikkeling
 
 ## Project Browser
 

--- a/embuild-analyses/public/data/bouwprojecten-gemeenten/projects_metadata.json
+++ b/embuild-analyses/public/data/bouwprojecten-gemeenten/projects_metadata.json
@@ -8,67 +8,67 @@
     "wegenbouw": {
       "id": "wegenbouw",
       "label": "Wegenbouw & Infrastructuur",
-      "emoji": "🛣️",
+      "emoji": "",
       "project_count": 1390
     },
     "riolering": {
       "id": "riolering",
       "label": "Riolering & Waterbeheer",
-      "emoji": "💧",
+      "emoji": "",
       "project_count": 449
     },
     "scholenbouw": {
       "id": "scholenbouw",
       "label": "Scholenbouw",
-      "emoji": "🏫",
+      "emoji": "",
       "project_count": 287
     },
     "sport": {
       "id": "sport",
       "label": "Sportinfrastructuur",
-      "emoji": "⚽",
+      "emoji": "",
       "project_count": 306
     },
     "cultuur": {
       "id": "cultuur",
       "label": "Culturele Infrastructuur",
-      "emoji": "🎭",
+      "emoji": "",
       "project_count": 416
     },
     "gebouwen": {
       "id": "gebouwen",
       "label": "Administratieve & Publieke Gebouwen",
-      "emoji": "🏢",
+      "emoji": "",
       "project_count": 160
     },
     "verlichting": {
       "id": "verlichting",
       "label": "Straatverlichting & Signalisatie",
-      "emoji": "💡",
+      "emoji": "",
       "project_count": 202
     },
     "groen": {
       "id": "groen",
       "label": "Groene Ruimte & Parks",
-      "emoji": "🌳",
+      "emoji": "",
       "project_count": 940
     },
     "ruimtelijke-ordening": {
       "id": "ruimtelijke-ordening",
       "label": "Ruimtelijke Ordening & Gebiedsontwikkeling",
-      "emoji": "🏘️",
+      "emoji": "",
       "project_count": 223
     },
     "zorg": {
       "id": "zorg",
       "label": "Sociale Infrastructuur & Zorg",
-      "emoji": "♿",
+      "emoji": "",
       "project_count": 734
     },
     "overige": {
       "id": "overige",
       "label": "Overige",
-      "emoji": "📋",
+      "emoji": "",
       "project_count": 2792
     }
   }

--- a/embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/ProjectBrowser.tsx
+++ b/embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/ProjectBrowser.tsx
@@ -228,7 +228,7 @@ export function ProjectBrowser() {
     <div className="space-y-6">
       {/* Header */}
       <div className="rounded-lg border bg-card p-6">
-        <h2 className="text-2xl font-bold mb-2">🔍 Project Browser - Bouwkansen 2026-2031</h2>
+        <h2 className="text-2xl font-bold mb-2">Project Browser - Bouwkansen 2026-2031</h2>
         <p className="text-muted-foreground">
           Doorzoek concrete investeringsprojecten uit de meerjarenplannen van Vlaamse gemeenten.
           Gebruik de filters om projecten te vinden die relevant zijn voor jouw sector.
@@ -238,7 +238,7 @@ export function ProjectBrowser() {
       {/* Partial failure warning */}
       {error && projects.length > 0 && (
         <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4">
-          <p className="text-yellow-800 text-sm">⚠️ {error}</p>
+          <p className="text-yellow-800 text-sm">{error}</p>
         </div>
       )}
 

--- a/embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/ProjectCard.tsx
+++ b/embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/ProjectCard.tsx
@@ -11,20 +11,6 @@ interface ProjectCardProps {
   onClick: () => void
 }
 
-const CATEGORY_EMOJIS: Record<string, string> = {
-  "wegenbouw": "🛣️",
-  "riolering": "💧",
-  "scholenbouw": "🏫",
-  "sport": "⚽",
-  "cultuur": "🎭",
-  "gebouwen": "🏢",
-  "verlichting": "💡",
-  "groen": "🌳",
-  "ruimtelijke-ordening": "🏘️",
-  "zorg": "♿",
-  "overige": "📋"
-}
-
 const CATEGORY_LABELS: Record<string, string> = {
   "wegenbouw": "Wegenbouw",
   "riolering": "Riolering",
@@ -75,7 +61,7 @@ export function ProjectCard({ project, onClick }: ProjectCardProps) {
         <div className="flex flex-wrap gap-1 mb-3">
           {project.categories.map(cat => (
             <Badge key={cat} variant="secondary" className="text-xs">
-              {CATEGORY_EMOJIS[cat]} {CATEGORY_LABELS[cat] || cat}
+              {CATEGORY_LABELS[cat] || cat}
             </Badge>
           ))}
         </div>

--- a/embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/ProjectDetailModal.tsx
+++ b/embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/ProjectDetailModal.tsx
@@ -19,19 +19,6 @@ interface ProjectDetailModalProps {
   metadata: ProjectMetadata | null
 }
 
-const CATEGORY_EMOJIS: Record<string, string> = {
-  "wegenbouw": "🛣️",
-  "riolering": "💧",
-  "scholenbouw": "🏫",
-  "sport": "⚽",
-  "cultuur": "🎭",
-  "gebouwen": "🏢",
-  "verlichting": "💡",
-  "groen": "🌳",
-  "ruimtelijke-ordening": "🏘️",
-  "zorg": "♿",
-  "overige": "📋"
-}
 
 export function ProjectDetailModal({
   project,
@@ -74,7 +61,7 @@ export function ProjectDetailModal({
               const cat = metadata?.categories[catId]
               return (
                 <Badge key={catId} variant="secondary">
-                  {CATEGORY_EMOJIS[catId]} {cat?.label || catId}
+                  {cat?.label || catId}
                 </Badge>
               )
             })}

--- a/embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/ProjectFilters.tsx
+++ b/embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/ProjectFilters.tsx
@@ -12,8 +12,18 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
-import { X, Search } from "lucide-react"
+import { X, Search, Check, ChevronsUpDown } from "lucide-react"
 import { useMemo, useState } from "react"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
 
 interface ProjectFiltersComponentProps {
   filters: ProjectFilters
@@ -33,6 +43,7 @@ export function ProjectFiltersComponent({
   setSortOption,
 }: ProjectFiltersComponentProps) {
   const [searchInput, setSearchInput] = useState("")
+  const [muniOpen, setMuniOpen] = useState(false)
 
   // Get unique municipalities from loaded projects
   const municipalities = useMemo(() => {
@@ -121,22 +132,63 @@ export function ProjectFiltersComponent({
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <Label htmlFor="municipality">Gemeente</Label>
-          <Select
-            value={filters.municipality || "all"}
-            onValueChange={handleMunicipalityChange}
-          >
-            <SelectTrigger id="municipality">
-              <SelectValue placeholder="Alle gemeenten" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Alle gemeenten</SelectItem>
-              {municipalities.map(muni => (
-                <SelectItem key={muni} value={muni}>
-                  {muni}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <Popover open={muniOpen} onOpenChange={setMuniOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                role="combobox"
+                aria-expanded={muniOpen}
+                className="w-full justify-between font-normal"
+                id="municipality"
+              >
+                {filters.municipality || "Alle gemeenten"}
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+              <Command>
+                <CommandInput placeholder="Zoek gemeente..." />
+                <CommandList>
+                  <CommandEmpty>Geen gemeente gevonden.</CommandEmpty>
+                  <CommandGroup>
+                    <CommandItem
+                      value="all"
+                      onSelect={() => {
+                        handleMunicipalityChange("all")
+                        setMuniOpen(false)
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4",
+                          !filters.municipality ? "opacity-100" : "opacity-0"
+                        )}
+                      />
+                      Alle gemeenten
+                    </CommandItem>
+                    {municipalities.map((muni) => (
+                      <CommandItem
+                        key={muni}
+                        value={muni}
+                        onSelect={(currentValue) => {
+                          handleMunicipalityChange(currentValue)
+                          setMuniOpen(false)
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            filters.municipality === muni ? "opacity-100" : "opacity-0"
+                          )}
+                        />
+                        {muni}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
         </div>
 
         <div>
@@ -171,7 +223,7 @@ export function ProjectFiltersComponent({
                     className="cursor-pointer hover:bg-primary/90"
                     onClick={() => handleCategoryToggle(id)}
                   >
-                    {cat.emoji} {cat.label} ({cat.project_count})
+                    {cat.label} ({cat.project_count})
                   </Badge>
                 )
               })}
@@ -200,7 +252,7 @@ export function ProjectFiltersComponent({
               const cat = metadata?.categories[catId]
               return (
                 <Badge key={catId} variant="secondary">
-                  {cat?.emoji} {cat?.label}
+                  {cat?.label}
                   <X
                     className="ml-1 h-3 w-3 cursor-pointer"
                     onClick={() => handleCategoryToggle(catId)}


### PR DESCRIPTION
This PR removes emoticons from the category badges, project cards, and content in the bouwprojecten-gemeenten analysis. It also includes the searchable municipality filter improvements.