### PR TITLE
fix: add missing properties to TooltipProps type

### DIFF
--- a/embuild-analyses/src/components/analyses/gemeentelijke-investeringen/InvesteringenDistributionPlot.tsx
+++ b/embuild-analyses/src/components/analyses/gemeentelijke-investeringen/InvesteringenDistributionPlot.tsx
@@ -122,6 +122,8 @@ export function InvesteringenDistributionPlot({
                 max: number
                 count: number
                 isHighlighted: boolean
+                medianValue: number
+                percentileLabel: string
             }
         }>
     }


### PR DESCRIPTION
Fixes TypeScript compilation error in InvesteringenDistributionPlot component.

The TooltipProps interface was missing `percentileLabel` and `medianValue` properties that are present in the actual bin objects, causing the build to fail.

Fixes #149

Generated with [Claude Code](https://claude.ai/code)