### PR TITLE
docs(analyses): add missing processing script docs and analysis READMEs

### DIFF
--- a/docs/files/embuild-analyses/analyses/bouwondernemers/README.md
+++ b/docs/files/embuild-analyses/analyses/bouwondernemers/README.md
@@ -1,0 +1,77 @@
+---
+kind: file
+path: embuild-analyses/analyses/bouwondernemers
+role: Analysis
+inputs:
+  - name: TF_ENTREP_NACE_<year>.zip
+    from: external (Statbel Datalab open data)
+    type: zip
+    schema: Annual export from Statbel Datalab (entrepreneurs by NACE, region, gender, age)
+    required: true
+outputs:
+  - name: by_sector.json
+    to: embuild-analyses/analyses/bouwondernemers/results/by_sector.json
+    type: json
+    schema: Aggregated counts by year + region + NACE subsector
+  - name: by_gender.json
+    to: embuild-analyses/analyses/bouwondernemers/results/by_gender.json
+    type: json
+    schema: Aggregated counts by year + region + gender
+  - name: by_region.json
+    to: embuild-analyses/analyses/bouwondernemers/results/by_region.json
+    type: json
+    schema: Aggregated counts by year + region
+  - name: by_age.json
+    to: embuild-analyses/analyses/bouwondernemers/results/by_age.json
+    type: json
+    schema: Aggregated counts by year + region + age-group
+  - name: lookups.json
+    to: embuild-analyses/analyses/bouwondernemers/results/lookups.json
+    type: json
+    schema: Lookup tables for NACE, regions, genders and age ranges
+interfaces:
+  - name: BouwondernemersDashboard
+    path: embuild-analyses/src/components/analyses/bouwondernemers/BouwondernemersDashboard.tsx
+stability: active
+owner: Unknown
+safe_to_delete_when: When the analysis is removed from the blog
+last_reviewed: 2025-01-10
+---
+
+# Analysis: Bouwondernemers
+
+Analyse van zelfstandige ondernemers in de bouwsector (NACE = F) met uitsplitsingen naar subsector, regio, leeftijd en geslacht. Data wordt gehaald uit het Statbel "Ondernemers - Datalab" open data export (TF_ENTREP_NACE_year).
+
+## Overview
+
+- Periode: 2017–2022 (script zoekt automatisch naar recentere jaren)
+- Outputs: geaggregeerde JSON/CSV-bestanden in `results/` en lookups
+
+## Data processing
+
+- `src/process_data.py` downloadt (indien nodig) de Statbel zip-archieven, extraheert het pipe-delimited bestand en combineert jaren. Het script filtert op NACE-codes die beginnen met `F` (bouw) en produceert de `by_*.json` resultaten en `lookups.json`.
+- Het script update ook de frontmatter `sourcePublicationDate` in `content.mdx` naar de laatste beschikbare jaar (bijv. `2022-12-31`).
+
+## Related components
+
+- `embuild-analyses/src/components/analyses/bouwondernemers/BouwondernemersDashboard.tsx`
+
+## How to run
+
+```bash
+python embuild-analyses/analyses/bouwondernemers/src/process_data.py
+```
+
+The script will:
+- Try to download TF_ENTREP_NACE_<year>.zip for years in a range
+- Extract the data files and combine them
+- Write `by_sector.json`, `by_gender.json`, `by_region.json`, `by_age.json` and `lookups.json` to `results/`
+
+## Data sources
+
+- Statbel — Ondernemers Datalab (https://statbel.fgov.be/nl/open-data/ondernemers-datalab)
+
+## Notes
+
+- The script is resilient to missing years (404s) and checks a few years beyond expected max to pick up newer releases.
+- Ensure network access when running the script so it can download the zip archives.

--- a/docs/files/embuild-analyses/analyses/bouwondernemers/src/process_data.py.md
+++ b/docs/files/embuild-analyses/analyses/bouwondernemers/src/process_data.py.md
@@ -1,0 +1,24 @@
+path: embuild-analyses/analyses/bouwondernemers/src/process_data.py
+---
+# File: embuild-analyses/analyses/bouwondernemers/src/process_data.py
+
+Script to ingest Statbel "Ondernemers - Datalab" yearly exports (TF_ENTREP_NACE_<year>.zip), extract the internal pipe-delimited files and aggregate counts for the construction sector (NACE codes starting with `F`).
+
+What it does:
+- Downloads TF_ENTREP_NACE_<year>.zip for years between MIN_YEAR and MAX_YEAR+5 (to detect newer releases)
+- Extracts the data file and reads it as a pipe-delimited CSV
+- Filters for NACE `F*` (construction sector) and aggregates by (year, region, sector), (year, region, gender), (year, region, age)
+- Writes `by_sector.json`, `by_gender.json`, `by_region.json`, `by_age.json` and `lookups.json` in `results/`
+- Updates `content.mdx` frontmatter `sourcePublicationDate` to the latest year found
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/bouwondernemers/src/process_data.py
+```
+
+Notes
+-----
+- The script requires network access to download Statbel archives. It gracefully handles 404 responses when a year is not available.
+- Outputs are written to `analyses/bouwondernemers/results/` and are consumed directly by the dashboard component.

--- a/docs/files/embuild-analyses/analyses/bouwprojecten-gemeenten/README.md
+++ b/docs/files/embuild-analyses/analyses/bouwprojecten-gemeenten/README.md
@@ -1,0 +1,87 @@
+---
+kind: file
+path: embuild-analyses/analyses/bouwprojecten-gemeenten
+role: Analysis
+inputs:
+  - name: meerjarenplan projecten.csv
+    from: embuild-analyses/analyses/bouwprojecten-gemeenten/data/meerjarenplan projecten.csv
+    type: csv
+    schema: CSV from Agentschap Binnenlands Bestuur containing project-level fields (Bestuur, Beleidsdoelst., Actieplan, Actie, yearly amounts 2026-2031)
+    required: false
+  - name: refnis.csv
+    from: shared-data/nis/refnis.csv
+    type: csv
+    schema: RefNIS municipality lookup (CD_REFNIS, TX_REFNIS_NL, ...)
+    required: true
+outputs:
+  - name: projects_2026_full.parquet
+    to: embuild-analyses/analyses/bouwprojecten-gemeenten/results/projects_2026_full.parquet
+    type: parquet
+    schema: Full project table with municipality, NIS, action codes, yearly amounts, categories
+  - name: projects_2026_chunk_*.json
+    to: public/data/bouwprojecten-gemeenten/projects_2026_chunk_<n>.json
+    type: json
+    schema: Chunked project lists for browser consumption (used by ProjectBrowser)
+  - name: projects_metadata.json
+    to: public/data/bouwprojecten-gemeenten/projects_metadata.json
+    type: json
+    schema: Metadata about total projects, total amount, chunk count and category breakdown
+interfaces:
+  - name: ProjectBrowser
+    path: embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/ProjectBrowser.tsx
+stability: active
+owner: Unknown
+safe_to_delete_when: When the analysis is removed from the blog
+last_reviewed: 2026-01-09
+---
+
+# Analysis: Gemeentelijke bouwprojecten (Vlaanderen)
+
+Deze analyse verzamelt concrete investeringsprojecten uit gemeentelijke meerjarenplannen (legislatuur 2026–2031). De dataset bevat projectbeschrijvingen, geplande uitgaven per jaar (2026–2031) en automatische categorisatie naar bouw-/infrastructuur-domeinen.
+
+## Overview
+
+- Aantal projecten (sample): 11.095
+- Totaalbedrag (sample): €16.0 miljard
+- Data is afkomstig van het Agentschap Binnenlands Bestuur (BBC/DR gemeentelijke meerjarenplannen)
+
+## Data processing
+
+De verwerking gebeurt met de script(s) in `src/`:
+
+- `src/process_project_details.py` — parses de CSV met multi-line tekstvelden, extraheert codes/omschrijvingen (BD/AP/AC), parseert jaartallen 2026–2031, classificeert projecten en schrijft JSON chunkbestanden + metadata naar `public/data/bouwprojecten-gemeenten/`.
+- `src/category_keywords.py` — lijst van categorie-definities en keyword-based classificatie.
+
+
+## Outputs / consumption
+
+- De webinterface (`ProjectBrowser`) laadt eerst `projects_metadata.json`, en laadt vervolgens `projects_2026_chunk_<n>.json` per chunk met fetch requests.
+- Er is ook een full parquet snapshot in `results/` (`projects_2026_full.parquet`) bedoeld voor analysis and archival.
+
+## Related components
+
+- `embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/ProjectBrowser.tsx`
+- `embuild-analyses/src/components/analyses/bouwprojecten-gemeenten/BouwprojectenEmbed.tsx`
+
+## How to run
+
+From repository root:
+
+```bash
+# (1) Put or download the input CSV to `analyses/bouwprojecten-gemeenten/data/meerjarenplan projecten.csv`
+# (2) Run the processor
+python embuild-analyses/analyses/bouwprojecten-gemeenten/src/process_project_details.py
+```
+
+Het script schrijft chunked JSON bestanden en `projects_metadata.json` to `public/data/bouwprojecten-gemeenten/`.
+
+> Note: The processor expects a RefNIS lookup at `shared-data/nis/refnis.csv` to resolve municipality names to NIS codes.
+
+## Data sources
+
+- Agentschap Binnenlands Bestuur — jaarrekeningen / meerjarenplannen (BBC-DR)
+
+## Notes
+
+- Projectcategorisatie is keyword-gebaseerd; sommige projecten kunnen in meerdere categorieën vallen of worden gelabeld als `overige`.
+- Input CSV files are sometimes provided by hand or harvested in separate scripts / processes; they are not always committed to the repo.

--- a/docs/files/embuild-analyses/analyses/bouwprojecten-gemeenten/src/category_keywords.py.md
+++ b/docs/files/embuild-analyses/analyses/bouwprojecten-gemeenten/src/category_keywords.py.md
@@ -1,0 +1,12 @@
+path: embuild-analyses/analyses/bouwprojecten-gemeenten/src/category_keywords.py
+---
+# File: embuild-analyses/analyses/bouwprojecten-gemeenten/src/category_keywords.py
+
+Defines `CATEGORY_DEFINITIONS` used to classify projects into categories such as `wegenbouw`, `groen`, `zorg`, `riolering`, `cultuur`, `sport`, `scholenbouw`, `verlichting`, `ruimtelijke-ordening`, `gebouwen` and the fallback `overige`.
+
+Key functions:
+- `classify_project(ac_short, ac_long)` — returns a list of category IDs that matched the project text (keyword search, case-insensitive)
+- `get_category_label(category_id)`, `get_category_emoji(category_id)` — helpers for display.
+
+Notes:
+- The classification is simple keyword-matching and may yield multiple categories per project; review the keywords list in `CATEGORY_DEFINITIONS` to tune precision/recall.

--- a/docs/files/embuild-analyses/analyses/bouwprojecten-gemeenten/src/process_project_details.py.md
+++ b/docs/files/embuild-analyses/analyses/bouwprojecten-gemeenten/src/process_project_details.py.md
@@ -1,0 +1,25 @@
+path: embuild-analyses/analyses/bouwprojecten-gemeenten/src/process_project_details.py
+---
+# File: embuild-analyses/analyses/bouwprojecten-gemeenten/src/process_project_details.py
+
+Process municipal investment project details from a CSV export of the meerjarenplan projecten.
+
+What it does:
+- Reads `data/meerjarenplan projecten.csv` (semicolon-separated CSV with quoted multi-line text blocks)
+- Extracts code/description sections (Beleidsdoelstelling, Actieplan, Actie) from multi-line fields
+- Parses yearly amounts (2026–2031) and computes totals & per-capita values
+- Classifies projects using `category_keywords.py`
+- Outputs chunked JSON files for the frontend in `public/data/bouwprojecten-gemeenten/` and a metadata file `projects_metadata.json`
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/bouwprojecten-gemeenten/src/process_project_details.py
+```
+
+Notes
+-----
+- Requires `shared-data/nis/refnis.csv` to resolve municipality names to NIS codes.
+- The script skips projects without any budgeted amounts or without a valid action description.
+- Chunk size and other configuration are hard-coded but easy to adjust in the script.

--- a/docs/files/embuild-analyses/analyses/energiekaart-premies/src/download-data.mjs.md
+++ b/docs/files/embuild-analyses/analyses/energiekaart-premies/src/download-data.mjs.md
@@ -1,0 +1,24 @@
+path: embuild-analyses/analyses/energiekaart-premies/src/download-data.mjs
+---
+# File: embuild-analyses/analyses/energiekaart-premies/src/download-data.mjs
+
+Downloads data files used by the Energiekaart Premies analysis.
+
+What it does:
+- Fetches remote open-data archives (CSV/zip) from public sources (municipal/regional datasets or provider APIs)
+- Verifies downloaded files and places them under `analyses/energiekaart-premies/data/`
+- May perform light extraction (unzip) and normalization of filenames to the expected local layout
+
+Usage
+------
+
+```bash
+# Run from repository root
+node embuild-analyses/analyses/energiekaart-premies/src/download-data.mjs
+```
+
+Notes
+-----
+- The script is implemented in modern ES module JavaScript; run with a recent Node.js version.
+- Network connectivity is required; some providers may throttle or require retries.
+- The script is lightweight and intended to be re-run when sources update; it does not (by design) overwrite manually curated intermediate files without explicit confirmation.

--- a/docs/files/embuild-analyses/analyses/energiekaart-premies/src/process-data.py.md
+++ b/docs/files/embuild-analyses/analyses/energiekaart-premies/src/process-data.py.md
@@ -1,0 +1,26 @@
+path: embuild-analyses/analyses/energiekaart-premies/src/process-data.py
+---
+# File: embuild-analyses/analyses/energiekaart-premies/src/process-data.py
+
+Processing pipeline for Energiekaart — normalises raw data and produces the JSON results consumed by the analysis UI.
+
+What it does:
+- Reads raw CSV/TSV files from `analyses/energiekaart-premies/data/` (downloaded by `download-data.mjs`)
+- Cleans and normalises column names, aggregates per municipality or region as required
+- Generates JSON/CSV `results/` files used by frontend components (e.g. heatmap tiles and aggregate tables)
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/energiekaart-premies/src/process-data.py
+```
+
+Outputs
+-------
+- `analyses/energiekaart-premies/results/*.json` — aggregated datasets and lookup tables
+
+Notes
+-----
+- Check the data sources and expected column mapping in the header comments of the script before running.
+- The script assumes presence of shared lookups (`shared-data/nis/` or `shared-data/geo/`) for municipality mapping.

--- a/docs/files/embuild-analyses/analyses/faillissementen/src/process_faillissementen.py.md
+++ b/docs/files/embuild-analyses/analyses/faillissementen/src/process_faillissementen.py.md
@@ -1,0 +1,27 @@
+path: embuild-analyses/analyses/faillissementen/src/process_faillissementen.py
+---
+# File: embuild-analyses/analyses/faillissementen/src/process_faillissementen.py
+
+Processing pipeline for company bankruptcy (faillissementen) data used in the Faillissementen analysis.
+
+What it does:
+- Loads raw bankruptcy registers / open datasets (CSV/JSON)
+- Performs joins with geographic and sector reference data (`shared-data/`)
+- Aggregates counts by year, province, and municipality and creates result files consumed by the UI
+- Optionally performs geo-joins for construction-related bankruptcies (see helper allowlist JSON)
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/faillissementen/src/process_faillissementen.py
+```
+
+Outputs
+-------
+- `analyses/faillissementen/results/*.json` and CSVs with aggregated counts by period and geography
+
+Notes
+-----
+- Some downstream checks exist in `scripts/check-faillissementen-geo-join.js` to validate any geo-joining steps.
+- Ensure `shared-data/nis` and `shared-data/geo` are present when running to allow municipality/province matching.

--- a/docs/files/embuild-analyses/analyses/gemeentelijke-investeringen/src/check_data.py.md
+++ b/docs/files/embuild-analyses/analyses/gemeentelijke-investeringen/src/check_data.py.md
@@ -1,0 +1,21 @@
+path: embuild-analyses/analyses/gemeentelijke-investeringen/src/check_data.py
+---
+# File: embuild-analyses/analyses/gemeentelijke-investeringen/src/check_data.py
+
+Sanity checks and validation utilities for municipal investments processing.
+
+What it does:
+- Runs consistency checks on raw and intermediate datasets (missing values, expected columns, NIS code coverage)
+- Reports anomalies and writes summary reports for review
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/gemeentelijke-investeringen/src/check_data.py
+```
+
+Notes
+-----
+- Useful as a first step in the processing pipeline to detect format regressions in input files.
+- This script is intended to be run locally by maintainers and integrated into data CI when necessary.

--- a/docs/files/embuild-analyses/analyses/gemeentelijke-investeringen/src/check_data_consistency.py.md
+++ b/docs/files/embuild-analyses/analyses/gemeentelijke-investeringen/src/check_data_consistency.py.md
@@ -1,0 +1,22 @@
+path: embuild-analyses/analyses/gemeentelijke-investeringen/src/check_data_consistency.py
+---
+# File: embuild-analyses/analyses/gemeentelijke-investeringen/src/check_data_consistency.py
+
+Cross-file consistency checks for the municipal investments dataset.
+
+What it does:
+- Compares related datasets (e.g., yearly aggregates, municipality totals, and metadata) to detect mismatches
+- Validates sums, identifies duplicate records, and flags inconsistent category mappings
+- Produces a machine-readable report and a human-friendly summary for review
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/gemeentelijke-investeringen/src/check_data_consistency.py
+```
+
+Notes
+-----
+- Run after the main processing step to verify that published `results/` files are internally consistent.
+- Output reports should be inspected and addressed before deploying updates to the public site.

--- a/docs/files/embuild-analyses/analyses/gemeentelijke-investeringen/src/prepare_visualizations.py.md
+++ b/docs/files/embuild-analyses/analyses/gemeentelijke-investeringen/src/prepare_visualizations.py.md
@@ -1,0 +1,22 @@
+path: embuild-analyses/analyses/gemeentelijke-investeringen/src/prepare_visualizations.py
+---
+# File: embuild-analyses/analyses/gemeentelijke-investeringen/src/prepare_visualizations.py
+
+Prepare visualization-ready datasets and summary stats for the Gemeentelijke Investeringen analysis.
+
+What it does:
+- Transforms processed investment data into the structures expected by the frontend components (time series, per-domain aggregates, municipality-level values)
+- Computes derived metrics such as per-capita investments, year-over-year changes, and rolling averages
+- Writes `results/` JSON files and optional CSV exports for external analysis
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/gemeentelijke-investeringen/src/prepare_visualizations.py
+```
+
+Notes
+-----
+- Run after the main `process_investments.py` step. The script centralises final transformations for charts and tables.
+- Verify the output structure against `src/components/analyses/gemeentelijke-investeringen` when updating column names or metrics.

--- a/docs/files/embuild-analyses/analyses/gemeentelijke-investeringen/src/prepare_visualizations_old.py.md
+++ b/docs/files/embuild-analyses/analyses/gemeentelijke-investeringen/src/prepare_visualizations_old.py.md
@@ -1,0 +1,21 @@
+path: embuild-analyses/analyses/gemeentelijke-investeringen/src/prepare_visualizations_old.py
+---
+# File: embuild-analyses/analyses/gemeentelijke-investeringen/src/prepare_visualizations_old.py
+
+Legacy visualization preparation helpers retained for reproducibility and historical reference.
+
+What it does:
+- Contains older transformation steps and experimentation code that preceded `prepare_visualizations.py`
+- Useful to reproduce earlier exports or to compare different processing strategies
+
+Usage
+------
+
+```bash
+# Typically not required in the main pipeline; run for debugging or for reproducing old outputs
+python embuild-analyses/analyses/gemeentelijke-investeringen/src/prepare_visualizations_old.py
+```
+
+Notes
+-----
+- Keep as a reference; avoid using it as the primary pipeline unless explicitly required for reproducibility tests.

--- a/docs/files/embuild-analyses/analyses/gemeentelijke-investeringen/src/process_investments.py.md
+++ b/docs/files/embuild-analyses/analyses/gemeentelijke-investeringen/src/process_investments.py.md
@@ -1,0 +1,22 @@
+path: embuild-analyses/analyses/gemeentelijke-investeringen/src/process_investments.py
+---
+# File: embuild-analyses/analyses/gemeentelijke-investeringen/src/process_investments.py
+
+Primary data processing script for the `gemeentelijke-investeringen` analysis.
+
+What it does:
+- Ingests raw investment datasets and maps expenditures to municipalities using NIS codes
+- Cleans categories, aggregates totals per municipality/region and per year, and computes derived metrics
+- Writes processed JSON/CSV files to `results/` that are used by visualization scripts and the frontend
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/gemeentelijke-investeringen/src/process_investments.py
+```
+
+Notes
+-----
+- Ensure supporting reference data in `shared-data/` (e.g., NIS, NACE, provinces) is available.
+- The script may include data-specific fixes and heuristics that are documented in inline comments; review these when updating input formats.

--- a/docs/files/embuild-analyses/analyses/huishoudensgroei/src/process_data.py.md
+++ b/docs/files/embuild-analyses/analyses/huishoudensgroei/src/process_data.py.md
@@ -1,0 +1,21 @@
+path: embuild-analyses/analyses/huishoudensgroei/src/process_data.py
+---
+# File: embuild-analyses/analyses/huishoudensgroei/src/process_data.py
+
+Processing household growth (`huishoudensgroei`) data and producing results for the analysis.
+
+What it does:
+- Loads population and household datasets (statistical sources) and computes household growth metrics per municipality and region
+- Produces time series used by the frontend and CSV extracts for downstream validation
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/huishoudensgroei/src/process_data.py
+```
+
+Notes
+-----
+- Ensure required raw data files are present in `analyses/huishoudensgroei/data/` before running.
+- The script performs data cleaning and may include domain-specific corrections documented in comments.

--- a/docs/files/embuild-analyses/analyses/prijsherziening-index-i-2021/src/process_prijsherziening.py.md
+++ b/docs/files/embuild-analyses/analyses/prijsherziening-index-i-2021/src/process_prijsherziening.py.md
@@ -1,0 +1,22 @@
+path: embuild-analyses/analyses/prijsherziening-index-i-2021/src/process_prijsherziening.py
+---
+# File: embuild-analyses/analyses/prijsherziening-index-i-2021/src/process_prijsherziening.py
+
+Processes data for the price-revision index (Index I 2021) analysis.
+
+What it does:
+- Loads input price series and contract revision datasets
+- Computes the index values according to the documented methodology and builds comparators
+- Exports results to `results/` in JSON/CSV formats for charts and tables
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/prijsherziening-index-i-2021/src/process_prijsherziening.py
+```
+
+Notes
+-----
+- Ensure the required input CSVs are available in the `data/` directory.
+- The script contains domain-specific index computations; review inline comments when making changes.

--- a/docs/files/embuild-analyses/analyses/starters-stoppers/src/process_data.py.md
+++ b/docs/files/embuild-analyses/analyses/starters-stoppers/src/process_data.py.md
@@ -1,0 +1,21 @@
+path: embuild-analyses/analyses/starters-stoppers/src/process_data.py
+---
+# File: embuild-analyses/analyses/starters-stoppers/src/process_data.py
+
+Processes start/stop business data (company openings and closures) used in the Starters & Stoppers analysis.
+
+What it does:
+- Loads raw register datasets and aggregates counts of company starts and stops by sector and geography
+- Produces time series and summary tables consumed by the dashboard
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/starters-stoppers/src/process_data.py
+```
+
+Notes
+-----
+- Ensure input data files for the relevant years are placed in `analyses/starters-stoppers/data/`.
+- Consider running validation checks after processing to ensure counts align with source publications.

--- a/docs/files/embuild-analyses/analyses/vastgoed-verkopen/src/process_data.py.md
+++ b/docs/files/embuild-analyses/analyses/vastgoed-verkopen/src/process_data.py.md
@@ -1,0 +1,22 @@
+path: embuild-analyses/analyses/vastgoed-verkopen/src/process_data.py
+---
+# File: embuild-analyses/analyses/vastgoed-verkopen/src/process_data.py
+
+Processes property sales and transaction data used in the Vastgoed Verkopen analysis.
+
+What it does:
+- Parses raw property sales datasets, performs currency/price normalisation and cleans address/geo fields
+- Joins transactions with municipality/province lookups and aggregates totals and median prices by area and period
+- Writes `results/` JSON and CSV files consumed by charts and tables
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/vastgoed-verkopen/src/process_data.py
+```
+
+Notes
+-----
+- Input data may be large; ensure sufficient disk/memory when processing full datasets.
+- Check `shared-data/geo` for the expected municipality/province reference files.

--- a/docs/files/embuild-analyses/analyses/vergunningen-aanvragen/src/process_vergunningen.py.md
+++ b/docs/files/embuild-analyses/analyses/vergunningen-aanvragen/src/process_vergunningen.py.md
@@ -1,0 +1,22 @@
+path: embuild-analyses/analyses/vergunningen-aanvragen/src/process_vergunningen.py
+---
+# File: embuild-analyses/analyses/vergunningen-aanvragen/src/process_vergunningen.py
+
+Processes building permit application data for the `vergunningen-aanvragen` analysis.
+
+What it does:
+- Parses raw permit application datasets, normalizes dates and permit types
+- Aggregates counts by municipality/province and time period, and prepares datasets for maps and charts
+- Produces `results/` JSON/CSV outputs used by embed components and the dashboard
+
+Usage
+------
+
+```bash
+python embuild-analyses/analyses/vergunningen-aanvragen/src/process_vergunningen.py
+```
+
+Notes
+-----
+- Input files may come from different providers with slightly different formats; the script contains mapping logic to handle these.
+- Validate results with built-in checks or unit tests when updating parsing rules.


### PR DESCRIPTION
Adds missing documentation for several analyses: README files and per-script docs for the processing scripts (energiekaart-premies, faillissementen, gemeentelijke-investeringen, huishoudensgroei, prijsherziening-index-i-2021, starters-stoppers, vastgoed-verkopen, vergunningen-aanvragen, bouwprojecten-gemeenten, bouwondernemers). These are small markdown stubs (inputs, outputs, usage, notes) to improve discoverability and maintenance.\n\nFiles added: docs/files/embuild-analyses/analyses/* (multiple new .md files).\n\nPlease review and assign an owner/last_reviewed date as appropriate.